### PR TITLE
IPP SAML Enhancements and Bug Fixes

### DIFF
--- a/api/src/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/org/apache/cloudstack/api/ApiConstants.java
@@ -590,6 +590,7 @@ public class ApiConstants {
     public static final String VMGROUP_ID = "vmgroupid";
     public static final String CS_URL = "csurl";
     public static final String IDP_ID = "idpid";
+    public static final String REDIRECT_ON_ERROR = "redirectonerror";
     public static final String SCALEUP_POLICY_IDS = "scaleuppolicyids";
     public static final String SCALEDOWN_POLICY_IDS = "scaledownpolicyids";
     public static final String SCALEUP_POLICIES = "scaleuppolicies";

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/ListAndSwitchSAMLAccountCmd.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/ListAndSwitchSAMLAccountCmd.java
@@ -154,7 +154,8 @@ public class ListAndSwitchSAMLAccountCmd extends BaseCmd implements APIAuthentic
                     final LoginCmdResponse loginResponse = (LoginCmdResponse) _apiServer.loginUser(session, nextUserAccount.getUsername(), nextUserAccount.getUsername() + nextUserAccount.getSource().toString(),
                             nextUserAccount.getDomainId(), null, remoteAddress, params);
                     SAMLUtils.setupSamlUserCookies(loginResponse, resp);
-                    resp.sendRedirect(SAML2AuthManager.SAMLCloudStackRedirectionUrl.value());
+
+                    SAMLUtils.redirectToSAMLCloudStackRedirectionUrl(resp, req);
                     return ApiResponseSerializer.toSerializedString(loginResponse, responseType);
                 }
             } catch (CloudAuthenticationException | IOException exception) {

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/SAML2LogoutAPIAuthenticatorCmd.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/SAML2LogoutAPIAuthenticatorCmd.java
@@ -18,6 +18,8 @@ package org.apache.cloudstack.api.command;
 
 import com.cloud.api.response.ApiResponseSerializer;
 import com.cloud.user.Account;
+import com.google.common.base.Strings;
+
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.ApiServerService;
@@ -31,13 +33,14 @@ import org.apache.cloudstack.saml.SAML2AuthManager;
 import org.apache.cloudstack.saml.SAMLPluginConstants;
 import org.apache.cloudstack.saml.SAMLProviderMetadata;
 import org.apache.cloudstack.saml.SAMLUtils;
+import org.apache.cloudstack.saml.SAMLTokenVO;
 import org.apache.log4j.Logger;
 import org.opensaml.DefaultBootstrap;
-import org.opensaml.saml2.core.LogoutRequest;
 import org.opensaml.saml2.core.Response;
+import org.opensaml.saml2.core.LogoutRequest;
+import org.opensaml.saml2.core.SessionIndex;
 import org.opensaml.saml2.core.StatusCode;
 import org.opensaml.xml.ConfigurationException;
-import org.opensaml.xml.io.MarshallingException;
 import org.opensaml.xml.io.UnmarshallingException;
 import org.xml.sax.SAXException;
 
@@ -51,6 +54,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.net.InetAddress;
+import org.apache.commons.lang.math.NumberUtils;
 
 @APICommand(name = "samlSlo", description = "SAML Global Log Out API", responseObject = LogoutCmdResponse.class, entityType = {})
 public class SAML2LogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthenticator {
@@ -82,6 +86,17 @@ public class SAML2LogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthen
         throw new ServerApiException(ApiErrorCode.METHOD_NOT_ALLOWED, "This is an authentication api, cannot be used directly");
     }
 
+    public LogoutRequest processSAMLRequest(String requestMessage) {
+        LogoutRequest requestObject = null;
+        try {
+            DefaultBootstrap.bootstrap();
+            requestObject = SAMLUtils.decodeSAMLLogoutRequest(requestMessage);
+        } catch (ConfigurationException | FactoryConfigurationError | ParserConfigurationException | SAXException | IOException | UnmarshallingException e) {
+            s_logger.error("SAMLRequest processing error: " + e.getMessage());
+        }
+        return requestObject;
+    }
+
     @Override
     public String authenticate(String command, Map<String, Object[]> params, HttpSession session, InetAddress remoteAddress, String responseType, StringBuilder auditTrailSb, final HttpServletRequest req, final HttpServletResponse resp) throws ServerApiException {
         auditTrailSb.append("=== SAML SLO Logging out ===");
@@ -90,9 +105,9 @@ public class SAML2LogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthen
         response.setResponseName(getCommandName());
         String responseString = ApiResponseSerializer.toSerializedString(response, responseType);
 
-        if (session == null) {
+        if (session == null && !(params != null && params.containsKey("SAMLRequest"))) {
             try {
-                resp.sendRedirect(SAML2AuthManager.SAMLCloudStackRedirectionUrl.value());
+                SAMLUtils.redirectToSAMLCloudStackRedirectionUrl(resp, req);
             } catch (IOException ignored) {
                 s_logger.info("[ignored] sending redirected failed.", ignored);
             }
@@ -108,7 +123,17 @@ public class SAML2LogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthen
                     params, responseType));
         }
 
-        if (params != null && params.containsKey("SAMLResponse")) {
+        if (params != null && params.containsKey("SAMLRequest")) {
+            try {
+                idPInitiatedSlo(params, session, req, resp);
+            } catch (ConfigurationException | ParserConfigurationException | SAXException | IOException | UnmarshallingException e) {
+                s_logger.error("SAMLRequest processing error: " + e.getMessage());
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, _apiServer.getSerializedApiError(ApiErrorCode.INTERNAL_ERROR.getHttpCode(),
+                            "SAML SLO unable to process IdP LogoffRequest",
+                            params, responseType));
+            }
+            return responseString;
+        } else if (params != null && params.containsKey("SAMLResponse")) {
             try {
                 final String samlResponse = ((String[])params.get(SAMLPluginConstants.SAML_RESPONSE))[0];
                 Response processedSAMLResponse = SAMLUtils.decodeSAMLResponse(samlResponse);
@@ -122,7 +147,7 @@ public class SAML2LogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthen
                 s_logger.error("SAMLResponse processing error: " + e.getMessage());
             }
             try {
-                resp.sendRedirect(SAML2AuthManager.SAMLCloudStackRedirectionUrl.value());
+                SAMLUtils.redirectToSAMLCloudStackRedirectionUrl(resp, req);
             } catch (IOException ignored) {
                 s_logger.info("[ignored] second redirected sending failed.", ignored);
             }
@@ -134,18 +159,17 @@ public class SAML2LogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthen
         String nameId = (String) session.getAttribute(SAMLPluginConstants.SAML_NAMEID);
         if (idpMetadata == null || nameId == null || nameId.isEmpty()) {
             try {
-                resp.sendRedirect(SAML2AuthManager.SAMLCloudStackRedirectionUrl.value());
+                SAMLUtils.redirectToSAMLCloudStackRedirectionUrl(resp, req);
             } catch (IOException ignored) {
                 s_logger.info("[ignored] final redirected failed.", ignored);
             }
             return responseString;
         }
-        LogoutRequest logoutRequest = SAMLUtils.buildLogoutRequest(idpMetadata.getSloUrl(), _samlAuthManager.getSPMetadata().getEntityId(), nameId);
 
         try {
-            String redirectUrl = idpMetadata.getSloUrl() + "?SAMLRequest=" + SAMLUtils.encodeSAMLRequest(logoutRequest);
+            String redirectUrl = SAMLUtils.buildLogoutRequestUrl(nameId, _samlAuthManager.getSPMetadata(), idpMetadata, SAML2AuthManager.SAMLSignatureAlgorithm.value());
             resp.sendRedirect(redirectUrl);
-        } catch (MarshallingException | IOException e) {
+        } catch (IOException e) {
             s_logger.error("SAML SLO error: " + e.getMessage());
             throw new ServerApiException(ApiErrorCode.ACCOUNT_ERROR, _apiServer.getSerializedApiError(ApiErrorCode.ACCOUNT_ERROR.getHttpCode(),
                     "SAML Single Logout Error",
@@ -169,5 +193,77 @@ public class SAML2LogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthen
         if (_samlAuthManager == null) {
             s_logger.error("No suitable Pluggable Authentication Manager found for SAML2 Login Cmd");
         }
+    }
+
+    public boolean idPInitiatedSlo(Map<String, Object[]> params, HttpSession session, final HttpServletRequest req, final HttpServletResponse resp) throws ConfigurationException, ParserConfigurationException, SAXException, IOException, UnmarshallingException {
+        if (params != null && params.containsKey("SAMLRequest")) {
+            s_logger.debug("SAML IdP initiated Slo");
+            SAMLProviderMetadata spMetadata = _samlAuthManager.getSPMetadata();
+            SAMLProviderMetadata idpMetadata = null;
+            LogoutRequest processedSAMLRequest = null;
+
+            final String samlRequest = ((String[])params.get(SAMLPluginConstants.SAML_REQUEST))[0];
+            processedSAMLRequest = SAMLUtils.decodeSAMLLogoutRequest(samlRequest);
+            if (processedSAMLRequest != null) {
+                String idpId = processedSAMLRequest.getIssuer().getValue();
+                idpMetadata = _samlAuthManager.getIdPMetadata(idpId);
+                if (idpMetadata == null) {
+                    s_logger.debug("SAML unknown IdP requesting Logout (" + idpId + "), sending request denied");
+                    idpMetadata = new SAMLProviderMetadata();
+                    idpMetadata.setEntityId(idpId);
+                    try {
+                        resp.sendRedirect(SAMLUtils.buildLogoutResponseUrl(processedSAMLRequest.getID(), spMetadata, idpMetadata, StatusCode.REQUEST_DENIED_URI, null, SAML2AuthManager.SAMLSignatureAlgorithm.value()));
+                    } catch (IOException ignored) {
+                        s_logger.error("[ignored] SAML IOException sending Slo request denied to IdP.", ignored);
+                    }
+                }
+                final String currentUrl = SAMLUtils.getCurrentUrl(req);
+                final String prevUrl = (params.containsKey("prevUrl")) ? ((String[])params.get("prevUrl"))[0] : null;
+                int attempt = (params.containsKey("attempt")) ? NumberUtils.toInt(((String[])params.get("attempt"))[0]) : (currentUrl == prevUrl) ? 1 : 0;
+                String targetSessionIndex = null;
+                final List<SessionIndex> sessionIndexes = processedSAMLRequest.getSessionIndexes();
+                for (SessionIndex sessionIndex : sessionIndexes) {
+                    if (sessionIndex.getSessionIndex() != null) {
+                        targetSessionIndex = sessionIndex.getSessionIndex();
+                        break;
+                    }
+                }
+                final String samlSessionIndex = (session == null) ? null : ((SAMLTokenVO)session.getAttribute(SAMLPluginConstants.SAML_TOKEN)).getSessionIndex();
+                final SAMLTokenVO token = (targetSessionIndex == null) ? null : _samlAuthManager.getTokenBySessionIndexWhereNotSpBaseUrl(targetSessionIndex, SAMLUtils.getBaseUrl(req));
+                final String altSloUrl = (token != null && !Strings.isNullOrEmpty(token.getSpBaseUrl())) ? SAMLUtils.replaceBaseUrl(currentUrl,token.getSpBaseUrl()) : null;
+                s_logger.debug("Current URL: " + currentUrl + " alt URL is " + altSloUrl);
+                s_logger.debug("SAML received Slo for Session Index " + targetSessionIndex + " user's current Session Index is " + samlSessionIndex);
+                if (targetSessionIndex == null) {
+                    s_logger.debug("SAML SessionIndex missing from Slo request, sending failure");
+                    try {
+                        resp.sendRedirect(SAMLUtils.buildLogoutResponseUrl(processedSAMLRequest.getID(), spMetadata, idpMetadata, StatusCode.REQUESTER_URI, "No session Index in LogoffRequeset", SAML2AuthManager.SAMLSignatureAlgorithm.value()));
+                    } catch (IOException ignored) {
+                        s_logger.error("[ignored] SAML IOException sending Slo failure to IdP.", ignored);
+                    }
+                } else if (targetSessionIndex.equals(samlSessionIndex)) {
+                    s_logger.debug("SAML Idp initiated Slo successful, sending success");
+                    try {
+                        resp.sendRedirect(SAMLUtils.buildLogoutResponseUrl(processedSAMLRequest.getID(), spMetadata, idpMetadata, StatusCode.SUCCESS_URI, null, SAML2AuthManager.SAMLSignatureAlgorithm.value()));
+                        return true;
+                    } catch (IOException ignored) {
+                        s_logger.error("[ignored] SAML IOException sending Slo success to Idp.", ignored);
+                    }
+                } else if (attempt++ < 2) {
+                    final String postUrl = (altSloUrl != null) ? altSloUrl : currentUrl;
+                    s_logger.debug("SAML redirecting Slo request via post to " + postUrl + " (URL attempt " + attempt + ")");
+                    return SAMLUtils.redirectToSloUrlViaPost(resp, postUrl, currentUrl, samlRequest, attempt);
+                } else {
+                    s_logger.debug("SAML Session Index in Idp initiated Slo not found, sending failure");
+                    try {
+                        resp.sendRedirect(SAMLUtils.buildLogoutResponseUrl(processedSAMLRequest.getID(), spMetadata, idpMetadata, StatusCode.REQUESTER_URI, "No session Index in LogoffRequeset", SAML2AuthManager.SAMLSignatureAlgorithm.value()));
+                    } catch (IOException ignored) {
+                        s_logger.error("[ignored] SAML IOException sending Slo failure to IdP.", ignored);
+                    }
+                }
+            } else {
+                s_logger.error("SAML IdP initiated LogoutRequest was null");
+            }
+        }
+        return false;
     }
 }

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAML2AuthManager.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAML2AuthManager.java
@@ -21,6 +21,7 @@ import com.cloud.utils.component.PluggableService;
 import org.apache.cloudstack.api.auth.PluggableAPIAuthenticator;
 import org.apache.cloudstack.framework.config.ConfigKey;
 
+import javax.servlet.http.HttpSession;
 import java.util.Collection;
 
 public interface SAML2AuthManager extends PluggableAPIAuthenticator, PluggableService {
@@ -70,6 +71,8 @@ public interface SAML2AuthManager extends PluggableAPIAuthenticator, PluggableSe
     public static final ConfigKey<Integer> SAMLTimeout = new ConfigKey<Integer>("Advanced", Integer.class, "saml2.timeout", "1800",
             "SAML2 IDP Metadata refresh interval in seconds, minimum value is set to 300", true);
 
+    public static final ConfigKey<Boolean> SAMLSupportHostnameAliases = new ConfigKey<Boolean>("Advanced", Boolean.class, "saml2.hostnameAliases.enabled", "false",
+            "Enables support for other Service Provider hostnames. Dynamically updates SSO URL and tracks and redirects to user's SLO URL for IdP initiated SLO.", true);
     public SAMLProviderMetadata getSPMetadata();
     public SAMLProviderMetadata getIdPMetadata(String entityId);
     public Collection<SAMLProviderMetadata> getAllIdPMetadata();
@@ -77,7 +80,11 @@ public interface SAML2AuthManager extends PluggableAPIAuthenticator, PluggableSe
     public boolean isUserAuthorized(Long userId, String entityId);
     public boolean authorizeUser(Long userId, String entityId, boolean enable);
 
-    public void saveToken(String authnId, String domain, String entity);
+    public void saveToken(String authnId, String domain, String entity, String samlNameId, String jsessionId);
+    public void updateToken(SAMLTokenVO token);
+    public void unauthorizeToken(SAMLTokenVO token);
     public SAMLTokenVO getToken(String authnId);
+    public SAMLTokenVO getTokenBySessionIndexWhereNotSpBaseUrl(String sessionIndex, String spBaseUrl);
     public void expireTokens();
+    public void attachTokenToSession(HttpSession session, SAMLTokenVO token);
 }

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLActiveUser.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLActiveUser.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.saml;
+/*import com.cloud.utils.db.DB;*/
+import javax.servlet.http.HttpSessionBindingListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+import javax.servlet.http.HttpSession;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SAMLActiveUser implements HttpSessionBindingListener {
+    private String id;
+    private SAMLTokenVO token;
+
+    private static final Logger s_logger = Logger.getLogger(SAMLActiveUser.class);
+    private SAMLTokenDao samlTokenDao;
+
+    public SAMLActiveUser (SAMLTokenDao samlTokenDao){
+        this.samlTokenDao = samlTokenDao;
+    }
+
+    @Override
+    public void valueBound(HttpSessionBindingEvent event) {
+        final HttpSession session = event.getSession();
+        if (session != null) {
+            id = session.getId();
+            token = (SAMLTokenVO)session.getAttribute(SAMLPluginConstants.SAML_TOKEN);
+            if (token == null) {
+                s_logger.error("token not found in session attributes");
+            } else {
+                s_logger.debug("Bound listener to active SAML user with token ID of " + token.getId() + " and UUID of " + token.getUuid());
+            }
+        } else {
+            s_logger.error("event.getSession() returned null");
+        }
+    }
+
+    @Override
+    public void valueUnbound(HttpSessionBindingEvent event) {
+        if (token != null) {
+            s_logger.debug("Removing token with ID " + token.getId());
+            samlTokenDao.remove(token.getId());
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null || !(this.getClass().isInstance(obj))) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        final SAMLActiveUser other = (SAMLActiveUser) obj;
+        return new EqualsBuilder().append(this.getId(), other.getId()).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(this.getClass())
+                .append(id)
+                .toHashCode();
+    }
+}

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLPluginConstants.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLPluginConstants.java
@@ -22,9 +22,14 @@ public class SAMLPluginConstants {
     public static final int SAML_REFRESH_INTERVAL = 300;
 
     public static final String SAML_RESPONSE = "SAMLResponse";
+    public static final String SAML_REQUEST = "SAMLRequest";
     public static final String SAML_IDPID = "SAML_IDPID";
+    public static final String SAML_INTERACTIVE_LOGIN = "SAML_INTERACTIVE_LOGIN";
+    public static final String SAML_LOGIN_MSG_COOKIE = "login-message";
     public static final String SAML_SESSIONID = "SAML_SESSIONID";
     public static final String SAML_NAMEID = "SAML_NAMEID";
+    public static final String SAML_TOKEN = "SAML_TOKEN";
+    public static final String SAML_SESSION_LISTENER = "SAML_SESSION_LISTENER";
     public static final String SAMLSP_KEYPAIR = "SAMLSP_KEYPAIR";
     public static final String SAMLSP_X509CERT = "SAMLSP_X509CERT";
 }

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLTokenDao.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLTokenDao.java
@@ -20,4 +20,6 @@ import com.cloud.utils.db.GenericDao;
 
 public interface SAMLTokenDao extends GenericDao<SAMLTokenVO, Long> {
     public void expireTokens();
+
+    public SAMLTokenVO findBySessionIndexWhereNotSpBaseUrl(final String sessionIndex, final String sloUrl);
 }

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLTokenDaoImpl.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLTokenDaoImpl.java
@@ -19,6 +19,8 @@ package org.apache.cloudstack.saml;
 import com.cloud.utils.db.DB;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.TransactionLegacy;
+import com.cloud.utils.db.SearchBuilder;
+import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.springframework.stereotype.Component;
 
@@ -27,9 +29,14 @@ import java.sql.PreparedStatement;
 @DB
 @Component
 public class SAMLTokenDaoImpl extends GenericDaoBase<SAMLTokenVO, Long> implements SAMLTokenDao {
+    protected final SearchBuilder<SAMLTokenVO> SessionIndexSearchNotSpBaseUrl;
 
     public SAMLTokenDaoImpl() {
         super();
+        SessionIndexSearchNotSpBaseUrl = createSearchBuilder();
+        SessionIndexSearchNotSpBaseUrl.and("session_index", SessionIndexSearchNotSpBaseUrl.entity().getSessionIndex(), SearchCriteria.Op.EQ);
+        SessionIndexSearchNotSpBaseUrl.and("sp_base_url", SessionIndexSearchNotSpBaseUrl.entity().getSpBaseUrl(), SearchCriteria.Op.NEQ);
+        SessionIndexSearchNotSpBaseUrl.done();
     }
 
     @Override
@@ -37,7 +44,7 @@ public class SAMLTokenDaoImpl extends GenericDaoBase<SAMLTokenVO, Long> implemen
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         try {
             txn.start();
-            String sql = "DELETE FROM `saml_token` WHERE `created` < (NOW() - INTERVAL 1 HOUR)";
+            String sql = "DELETE FROM `saml_token` WHERE `created` < (NOW() - INTERVAL 5 MINUTE) AND session_index IS NULL OR `created` < (NOW() - INTERVAL 24 HOUR) AND session_index IS NOT NULL";
             PreparedStatement pstmt = txn.prepareAutoCloseStatement(sql);
             pstmt.executeUpdate();
             txn.commit();
@@ -45,5 +52,13 @@ public class SAMLTokenDaoImpl extends GenericDaoBase<SAMLTokenVO, Long> implemen
             txn.rollback();
             throw new CloudRuntimeException("Unable to flush old SAML tokens due to exception", e);
         }
+    }
+
+    @Override
+    public SAMLTokenVO findBySessionIndexWhereNotSpBaseUrl(final String sessionIndex, final String spBaseUrl) {
+        SearchCriteria<SAMLTokenVO> sc = SessionIndexSearchNotSpBaseUrl.create();
+        sc.setParameters("session_index", sessionIndex);
+        sc.setParameters("sp_base_url", spBaseUrl);
+        return findOneBy(sc);
     }
 }

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLTokenVO.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLTokenVO.java
@@ -45,16 +45,24 @@ public class SAMLTokenVO implements Identity, InternalIdentity {
     @Column(name = "entity")
     private String entity = null;
 
+    @Column(name = "session_index")
+    private String sessionIndex = null;
+
+    @Column(name = "sp_base_url")
+    private String spBaseUrl = null;
+
     @Column(name = GenericDao.CREATED_COLUMN)
     private Date created;
 
     public SAMLTokenVO() {
     }
 
-    public SAMLTokenVO(String uuid, Long domainId, String entity) {
+    public SAMLTokenVO(String uuid, Long domainId, String entity, String sessionIndex, String spBaseUrl) {
         this.uuid = uuid;
         this.domainId = domainId;
         this.entity = entity;
+        this.sessionIndex = sessionIndex;
+        this.spBaseUrl = spBaseUrl;
     }
 
     @Override
@@ -85,6 +93,22 @@ public class SAMLTokenVO implements Identity, InternalIdentity {
 
     public void setEntity(String entity) {
         this.entity = entity;
+    }
+
+    public String getSessionIndex() {
+        return sessionIndex;
+    }
+
+    public void setSessionIndex(String sessionIndex) {
+        this.sessionIndex = sessionIndex;
+    }
+
+    public String getSpBaseUrl() {
+        return spBaseUrl;
+    }
+
+    public void setSpBaseUrl(String spBaseUrl) {
+        this.spBaseUrl = spBaseUrl;
     }
 
     public Date getCreated() {

--- a/plugins/user-authenticators/saml2/test/org/apache/cloudstack/SAML2AuthManagerImplTest.java
+++ b/plugins/user-authenticators/saml2/test/org/apache/cloudstack/SAML2AuthManagerImplTest.java
@@ -121,18 +121,18 @@ public class SAML2AuthManagerImplTest extends TestCase {
     public void testSaveToken() {
         // duplicate token test
         Mockito.when(samlTokenDao.findByUuid(Mockito.anyString())).thenReturn(new SAMLTokenVO());
-        saml2AuthManager.saveToken("someAuthnID", null, "https://idp.bhaisaab.org/profile/shibboleth");
+        saml2AuthManager.saveToken("someAuthnID", null, "https://idp.bhaisaab.org/profile/shibboleth", null, null);
         Mockito.verify(samlTokenDao, Mockito.times(0)).persist(Mockito.any(SAMLTokenVO.class));
 
         // valid test
         Mockito.when(samlTokenDao.findByUuid(Mockito.anyString())).thenReturn(null);
-        saml2AuthManager.saveToken("someAuthnID", null, "https://idp.bhaisaab.org/profile/shibboleth");
+        saml2AuthManager.saveToken("someAuthnID", null, "https://idp.bhaisaab.org/profile/shibboleth", null, null);
         Mockito.verify(samlTokenDao, Mockito.times(1)).persist(Mockito.any(SAMLTokenVO.class));
     }
 
     @Test
     public void testGetToken() {
-        SAMLTokenVO randomToken = new SAMLTokenVO("uuid", 1L, "someIDPDI");
+        SAMLTokenVO randomToken = new SAMLTokenVO("uuid", 1L, "someIDPDI", null, null);
         Mockito.when(samlTokenDao.findByUuid(Mockito.anyString())).thenReturn(randomToken);
         assertEquals(saml2AuthManager.getToken("someAuthnID"), randomToken);
     }

--- a/plugins/user-authenticators/saml2/test/org/apache/cloudstack/SAMLUtilsTest.java
+++ b/plugins/user-authenticators/saml2/test/org/apache/cloudstack/SAMLUtilsTest.java
@@ -55,7 +55,7 @@ public class SAMLUtilsTest extends TestCase {
         String logoutUrl = "http://logoutUrl";
         String spId = "cloudstack";
         String nameId = "_12345";
-        LogoutRequest req = SAMLUtils.buildLogoutRequest(logoutUrl, spId, nameId);
+        LogoutRequest req = SAMLUtils.buildLogoutRequestObject(logoutUrl, spId, nameId);
         assertEquals(req.getDestination(), logoutUrl);
         assertEquals(req.getIssuer().getValue(), spId);
     }

--- a/plugins/user-authenticators/saml2/test/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmdTest.java
+++ b/plugins/user-authenticators/saml2/test/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmdTest.java
@@ -139,11 +139,11 @@ public class SAML2LoginAPIAuthenticatorCmdTest {
     public void testAuthenticate() throws Exception {
         SAML2LoginAPIAuthenticatorCmd cmd = Mockito.spy(new SAML2LoginAPIAuthenticatorCmd());
 
-        Field apiServerField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("_apiServer");
+        Field apiServerField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("apiServer");
         apiServerField.setAccessible(true);
         apiServerField.set(cmd, apiServer);
 
-        Field managerField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("_samlAuthManager");
+        Field managerField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("samlAuthManager");
         managerField.setAccessible(true);
         managerField.set(cmd, samlAuthManager);
 
@@ -151,11 +151,11 @@ public class SAML2LoginAPIAuthenticatorCmdTest {
         accountServiceField.setAccessible(true);
         accountServiceField.set(cmd, accountService);
 
-        Field domainMgrField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("_domainMgr");
+        Field domainMgrField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("domainMgr");
         domainMgrField.setAccessible(true);
         domainMgrField.set(cmd, domainMgr);
 
-        Field userAccountDaoField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("_userAccountDao");
+        Field userAccountDaoField = SAML2LoginAPIAuthenticatorCmd.class.getDeclaredField("userAccountDao");
         userAccountDaoField.setAccessible(true);
         userAccountDaoField.set(cmd, userAccountDao);
 

--- a/ui/scripts/cloud.core.callbacks.js
+++ b/ui/scripts/cloud.core.callbacks.js
@@ -36,6 +36,9 @@ or it's the first time the user has come to this page.
 function onLogoutCallback() {
     g_loginResponse = null; //clear single signon variable g_loginResponse
 
+    if ($.cookie('login-option') !== 'cloudstack-login') {
+        $.cookie('login-message', 'You have been logged out.  Please close all open browser windows to fully sign-out.');
+    }
 
     return true; // return true means the login page will show
     /*

--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -406,7 +406,7 @@
                     }
                 }
 
-                var url = 'samlSso';
+                var url = 'samlSso&redirectonerror=true';
                 if (args.data.idpid) {
                     url = url + '&idpid=' + args.data.idpid;
                 }

--- a/ui/scripts/ui-custom/login.js
+++ b/ui/scripts/ui-custom/login.js
@@ -96,6 +96,10 @@
         // Login action
         var selectedLogin = 'cloudstack';
         $login.find('#login-submit').click(function() {
+            var selectedOption = $login.find('#login-options').find(':selected').val();
+            if ((selectedLogin === 'cloudstack' || selectedLogin === 'saml') && selectedOption && selectedOption !== '') {
+                $.cookie('login-option', selectedOption, {expires: 90});
+            }
             if (selectedLogin === 'cloudstack') {
                 // CloudStack Local Login
                 if (!$form.valid()) return false;
@@ -122,7 +126,7 @@
             } else if (selectedLogin === 'saml') {
                 // SAML
                 args.samlLoginAction({
-                    data: {'idpid': $login.find('#login-options').find(':selected').val()}
+                    data: {'idpid': selectedOption}
                 });
             }
             return false;
@@ -145,11 +149,7 @@
         };
 
         $login.find('#login-options').change(function() {
-            var selectedOption = $login.find('#login-options').find(':selected').val();
-            toggleLoginView(selectedOption);
-            if (selectedOption && selectedOption !== '') {
-                $.cookie('login-option', selectedOption);
-            }
+            toggleLoginView($login.find('#login-options').find(':selected').val());
         });
 
         // By Default hide login option dropdown
@@ -210,6 +210,11 @@
                     dictionary['label.loading'] + '...'
                 )
             ));
+        }
+
+        if ($.cookie('login-message')) {
+            $('div.login form').after('<div style="text-align:center;margin-top:50px;">' + $.cookie('login-message') + '</div>');
+            $.cookie('login-message',null);
         }
 
         $(window).trigger('cloudStack.init');


### PR DESCRIPTION
## Description

- Sign SLO requests created by CloudStack
- Fix issue with assertion encryption.  Was looking for a SP certificate to decrypt assertions from IDP.  In SAML, IDP generates a symmetrical key for encryption, and encrypts that key with the Public Key of the SP in the same XML as the assertion.  Changed code to check if SP has a public/private key pair and if so, check for and decrypt assertion.  Decryption was broken because code was checking if IDP had assigned a cert for encryption... which is incorrect and not how SAML XML encryption works.
- Added support for IDP initiated SLO.
- Added support for having multiple hostnames used to access CloudStack.  SAML uses hard-coded URLs, this needed manipulating since we do white-labeling

### Multiple hostnames for SAML
- Uses existing saml_token table, with new columns for SP_BaseURL and SAML's Session Index
- Uses SAML session index to track the correct base URL for a User/Session
- Redirects as needed to correct SP URL
- Performs multiple redirects as required to work-around for XSRF and cookies' "same site" property
- Created new class SAMLActiveUser that is attached to a user Session.  This class handles deleting the SAML_Token row associated with the user upon session logoff/expiration.  Also put in a 24 hour remove to ensure rows are cleaned up even in the event of a mgmt server restart or other circumstance where the new class isn't called to remove the row

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [-] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [-] Cleanup (Code refactoring and cleanup, that may add test cases)

## Possible issues
- Instead of using Spring DI to inject a SAMLTokenDao object into the class to use, ended up adding the object via a constructor
- When SAMLActiveUser created its own instance of SAMLTokenDao, we didn't have an active connection to the database upon session expiration.  Linking in SAMLTokenDao via a constructor is keeping database connection alive long enough.
