### PR TITLE
AC-87: server: Search zone-wide storage pool when allocation algothri…

### DIFF
--- a/engine/schema/src/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/com/cloud/capacity/dao/CapacityDao.java
@@ -56,5 +56,5 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     float findClusterConsumption(Long clusterId, short capacityType, long computeRequested);
 
-    List<Long> orderHostsByFreeCapacity(Long clusterId, short capacityType);
+    List<Long> orderHostsByFreeCapacity(Long zoneId, Long clusterId, short capacityType);
 }

--- a/engine/schema/src/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -903,22 +903,30 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
-    public List<Long> orderHostsByFreeCapacity(Long clusterId, short capacityTypeForOrdering){
+    public List<Long> orderHostsByFreeCapacity(Long zoneId, Long clusterId, short capacityTypeForOrdering){
          TransactionLegacy txn = TransactionLegacy.currentTxn();
          PreparedStatement pstmt = null;
          List<Long> result = new ArrayList<Long>();
          StringBuilder sql = new StringBuilder(ORDER_HOSTS_BY_FREE_CAPACITY_PART1);
-        if(clusterId != null) {
-            sql.append("AND cluster_id = ?");
+        if (zoneId != null) {
+            sql.append(" AND data_center_id = ?");
+        }
+        if (clusterId != null) {
+            sql.append(" AND cluster_id = ?");
         }
         sql.append(ORDER_HOSTS_BY_FREE_CAPACITY_PART2);
-         try {
+
+        try {
              pstmt = txn.prepareAutoCloseStatement(sql.toString());
              pstmt.setShort(1, capacityTypeForOrdering);
-             if(clusterId != null) {
-                pstmt.setLong(2, clusterId);
+             int index = 2;
+             if (zoneId != null) {
+                pstmt.setLong(index, zoneId);
+                index ++;
              }
-
+             if (clusterId != null) {
+                pstmt.setLong(index, clusterId);
+             }
              ResultSet rs = pstmt.executeQuery();
              while (rs.next()) {
                  result.add(rs.getLong(1));

--- a/engine/storage/src/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
@@ -106,6 +106,7 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
 
     protected List<StoragePool> reorderPoolsByCapacity(DeploymentPlan plan,
         List<StoragePool> pools) {
+        Long zoneId = plan.getDataCenterId();
         Long clusterId = plan.getClusterId();
         short capacityType;
         if(pools != null && pools.size() != 0){
@@ -115,7 +116,7 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
             return null;
         }
 
-        List<Long> poolIdsByCapacity = _capacityDao.orderHostsByFreeCapacity(clusterId, capacityType);
+        List<Long> poolIdsByCapacity = _capacityDao.orderHostsByFreeCapacity(zoneId, clusterId, capacityType);
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("List of pools in descending order of free capacity: "+ poolIdsByCapacity);
         }

--- a/server/src/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
+++ b/server/src/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
@@ -345,6 +345,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
 
     // Reorder hosts in the decreasing order of free capacity.
     private List<? extends Host> reorderHostsByCapacity(DeploymentPlan plan, List<? extends Host> hosts) {
+        Long zoneId = plan.getDataCenterId();
         Long clusterId = plan.getClusterId();
         //Get capacity by which we should reorder
         String capacityTypeToOrder = _configDao.getValue(Config.HostCapacityTypeToOrderClusters.key());
@@ -352,7 +353,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
         if("RAM".equalsIgnoreCase(capacityTypeToOrder)){
             capacityType = CapacityVO.CAPACITY_TYPE_MEMORY;
         }
-        List<Long> hostIdsByFreeCapacity = _capacityDao.orderHostsByFreeCapacity(clusterId, capacityType);
+        List<Long> hostIdsByFreeCapacity = _capacityDao.orderHostsByFreeCapacity(zoneId,clusterId, capacityType);
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("List of hosts in descending order of free capacity in the cluster: "+ hostIdsByFreeCapacity);
         }


### PR DESCRIPTION
AC-87: Zone-wide storage pool allocation doesn't work correctly with vm.allocation.algorithm set to firstfitleastconsumed

This PR was designed to bring some bug fixing done by the cloudstack community when using some different kind of algorithm named firstfitleastconsumed that is used for the best balance in the allocation of hardware resources.