### PR TITLE
AC-90 Add Instance Error

### DIFF
--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLUtils.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAMLUtils.java
@@ -441,7 +441,7 @@ public class SAMLUtils {
         resp.addCookie(new Cookie("domainid", URLEncoder.encode(loginResponse.getDomainId(), HttpUtils.UTF_8)));
         resp.addCookie(new Cookie("role", URLEncoder.encode(loginResponse.getType(), HttpUtils.UTF_8)));
         resp.addCookie(new Cookie("username", URLEncoder.encode(loginResponse.getUsername(), HttpUtils.UTF_8)));
-        resp.addCookie(new Cookie("account", URLEncoder.encode(loginResponse.getAccount(), HttpUtils.UTF_8)));
+        resp.addCookie(new Cookie("account", URLEncoder.encode(loginResponse.getAccount(), HttpUtils.UTF_8).replace("+", "%20")));
         String timezone = loginResponse.getTimeZone();
         if (timezone != null) {
             resp.addCookie(new Cookie("timezone", URLEncoder.encode(timezone, HttpUtils.UTF_8)));


### PR DESCRIPTION
When logged in via SSO the account 'IP Pathways' get's encoded with a '+' in Java when the cookies are created. JS doesn't decode this to a space because the method 'decodeURIComponent' isn't intended to handle that character. SAML plugin was already substituting '+' for '%20' in the full name cookie, so this was applied to the account name as well. I have tested that this does not result in double encoding of the values.