### PR TITLE
AC-79 decomission cluster

### DIFF
--- a/engine/components-api/src/com/cloud/deploy/DeploymentPlanningManager.java
+++ b/engine/components-api/src/com/cloud/deploy/DeploymentPlanningManager.java
@@ -21,12 +21,8 @@ import com.cloud.exception.AffinityConflictException;
 import com.cloud.exception.InsufficientServerCapacityException;
 import com.cloud.utils.component.Manager;
 import com.cloud.vm.VirtualMachineProfile;
-import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface DeploymentPlanningManager extends Manager {
-
-    ConfigKey<Boolean> drainDisabledClusters = new ConfigKey<>("Advanced", Boolean.class, "drain.disabled.clusters", "false",
-            "Drain VMs on disabled Clusters", true, ConfigKey.Scope.Cluster);
 
     /**
      * Manages vm deployment stages: First Process Affinity/Anti-affinity - Call

--- a/engine/components-api/src/com/cloud/deploy/DeploymentPlanningManager.java
+++ b/engine/components-api/src/com/cloud/deploy/DeploymentPlanningManager.java
@@ -21,8 +21,12 @@ import com.cloud.exception.AffinityConflictException;
 import com.cloud.exception.InsufficientServerCapacityException;
 import com.cloud.utils.component.Manager;
 import com.cloud.vm.VirtualMachineProfile;
+import org.apache.cloudstack.framework.config.ConfigKey;
 
 public interface DeploymentPlanningManager extends Manager {
+
+    ConfigKey<Boolean> drainDisabledClusters = new ConfigKey<>("Advanced", Boolean.class, "drain.disabled.clusters", "false",
+            "Drain VMs on disabled Clusters", true, ConfigKey.Scope.Cluster);
 
     /**
      * Manages vm deployment stages: First Process Affinity/Anti-affinity - Call

--- a/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
+++ b/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
@@ -298,4 +298,6 @@
     <bean id="indirectAgentLBService" class="org.apache.cloudstack.agent.lb.IndirectAgentLBServiceImpl" />
 
     <bean id="directDownloadManager" class="org.apache.cloudstack.direct.download.DirectDownloadManagerImpl" />
+
+    <bean id="clusterDrainingManager" class="org.apache.cloudstack.cluster.ClusterDrainingManagerImpl" />
 </beans>

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -289,6 +289,7 @@ import org.apache.cloudstack.api.response.VpcOfferingResponse;
 import org.apache.cloudstack.api.response.VpcResponse;
 import org.apache.cloudstack.api.response.VpnUsersResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
+import org.apache.cloudstack.cluster.ClusterDrainingManager;
 import org.apache.cloudstack.config.Configuration;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -361,6 +362,8 @@ public class ApiResponseHelper implements ResponseGenerator {
     private NicExtraDhcpOptionDao _nicExtraDhcpOptionDao;
     @Inject
     private IPAddressDao userIpAddressDao;
+    @Inject
+    protected ClusterDrainingManager _clusterDrainingManager;
 
     @Override
     public UserResponse createUserResponse(User user) {
@@ -1147,7 +1150,10 @@ public class ApiResponseHelper implements ResponseGenerator {
         }
         clusterResponse.setHypervisorType(cluster.getHypervisorType().toString());
         clusterResponse.setClusterType(cluster.getClusterType().toString());
-        clusterResponse.setAllocationState(cluster.getAllocationState().toString());
+        if (_clusterDrainingManager.isClusterDraining(cluster))
+            clusterResponse.setAllocationState("Draining");
+        else
+            clusterResponse.setAllocationState(cluster.getAllocationState().toString());
         clusterResponse.setManagedState(cluster.getManagedState().toString());
         String cpuOvercommitRatio = ApiDBUtils.findClusterDetails(cluster.getId(), "cpuOvercommitRatio");
         String memoryOvercommitRatio = ApiDBUtils.findClusterDetails(cluster.getId(), "memoryOvercommitRatio");

--- a/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -554,7 +554,6 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
      * Adds disabled resources (Data centers, Pods, Clusters) to exclude list (avoid) in case of disabled state.
      */
     public void avoidDisabledResources(DataCenter dc, ExcludeList avoids) {
-        avoidDisabledDataCenters(dc, avoids);
         avoidDisabledPods(dc, avoids);
         avoidDisabledClusters(dc, avoids);
     }
@@ -576,15 +575,6 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
     protected void avoidDisabledPods(DataCenter dc, ExcludeList avoids) {
         List<Long> disabledPods = _podDao.listDisabledPods(dc.getId());
         avoids.addPodList(disabledPods);
-    }
-
-    /**
-     * Adds disabled Data Centers (Zones) to the ExcludeList in order to avoid them at the deployment planner.
-     */
-    protected void avoidDisabledDataCenters(DataCenter dc, ExcludeList avoids) {
-        if (dc.getAllocationState() == Grouping.AllocationState.Disabled) {
-            avoids.addDataCenter(dc.getId());
-        }
     }
 
     @Override

--- a/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -551,7 +551,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
     }
 
     /**
-     * Adds disabled resources (Data centers, Pods, Clusters) to exclude list (avoid) in case of disabled state.
+     * Adds disabled resources (Pods, Clusters) to exclude list (avoid) in case of disabled state.
      */
     public void avoidDisabledResources(DataCenter dc, ExcludeList avoids) {
         avoidDisabledPods(dc, avoids);

--- a/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -33,8 +33,6 @@ import javax.naming.ConfigurationException;
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.fsm.StateMachine2;
 
-import org.apache.cloudstack.framework.config.ConfigKey;
-import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.affinity.AffinityGroupProcessor;
@@ -137,7 +135,7 @@ import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 public class DeploymentPlanningManagerImpl extends ManagerBase implements DeploymentPlanningManager, Manager, Listener,
-StateListener<State, VirtualMachine.Event, VirtualMachine>, Configurable {
+StateListener<State, VirtualMachine.Event, VirtualMachine> {
 
     private static final Logger s_logger = Logger.getLogger(DeploymentPlanningManagerImpl.class);
     @Inject
@@ -274,7 +272,6 @@ StateListener<State, VirtualMachine.Event, VirtualMachine>, Configurable {
 
         String haVmTag = (String)vmProfile.getParameter(VirtualMachineProfile.Param.HaTag);
 
-        // TODO: Nate - Add disabled clusters to avoid like in https://github.com/apache/cloudstack/commit/a3cdd1f836e40a4b4444af738780a337ee7aac1d#diff-beeb19d6661bbc4797c3a37da7b55d964ba344ff2af6d6ec495d16697c11fc99R293
         avoidDisabledResources(dc, avoids);
 
         if (plan.getHostId() != null && haVmTag == null) {
@@ -1656,15 +1653,5 @@ StateListener<State, VirtualMachine.Event, VirtualMachine>, Configurable {
         _reservationDao.expunge(sc);
       }
       return true;
-    }
-
-    @Override
-    public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {drainDisabledClusters};
-    }
-
-    @Override
-    public String getConfigComponentName() {
-        return DeploymentPlanningManager.class.getSimpleName();
     }
 }

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -517,6 +517,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     private static final ConfigKey<Boolean> AllowDeployVmIfGivenHostFails = new ConfigKey<Boolean>("Advanced", Boolean.class, "allow.deploy.vm.if.deploy.on.given.host.fails", "false",
             "allow vm to deploy on different host if vm fails to deploy on the given host ", true);
 
+   private static final ConfigKey<Boolean> drainDisabledOnReboot = new ConfigKey<>("Advanced", Boolean.class, "drain.disabled.on.reboot", "false",
+            "Drain VMs running on disabled clusters during reboot", true, ConfigKey.Scope.Cluster);
+
 
     @Override
     public UserVmVO getVirtualMachine(long vmId) {
@@ -902,7 +905,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         if (vm.getState() == State.Running && vm.getHostId() != null) {
             Host host = _hostDao.findById(vm.getHostId());
-            if (host.isDisabled()) {
+            if (host.isDisabled() && drainDisabledOnReboot.value()) {
                 s_logger.info("Performing full stop & start instead of reboot on vm " + vm.getInstanceName() + " due to host being disabled");
                 if (stopVirtualMachine(userId, vmId)) {
                     startVirtualMachine(vmId, null, null, null);
@@ -6419,7 +6422,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {EnableDynamicallyScaleVm, AllowUserExpungeRecoverVm, VmIpFetchWaitInterval, VmIpFetchTrialMax, VmIpFetchThreadPoolMax,
-            VmIpFetchTaskWorkers, AllowDeployVmIfGivenHostFails};
+            VmIpFetchTaskWorkers, AllowDeployVmIfGivenHostFails, drainDisabledOnReboot};
     }
 
     @Override

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -905,8 +905,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         if (vm.getState() == State.Running && vm.getHostId() != null) {
             boolean fullStopStart = false;
-            if (drainDisabledOnReboot.value()) {
-                Host host = _hostDao.findById(vm.getHostId());
+            Host host = _hostDao.findById(vm.getHostId());
+            if (drainDisabledOnReboot.valueIn(host.getClusterId())) {
                 Cluster cluster = _clusterDao.findById(host.getClusterId());
                 HostPodVO pod = _podDao.findById(cluster.getPodId());
                 if (host.isDisabled()

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -901,34 +901,42 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         if (vm.getState() == State.Running && vm.getHostId() != null) {
-            collectVmDiskStatistics(vm);
-            collectVmNetworkStatistics(vm);
-            DataCenterVO dc = _dcDao.findById(vm.getDataCenterId());
-            try {
-                if (dc.getNetworkType() == DataCenter.NetworkType.Advanced) {
-                    //List all networks of vm
-                    List<Long> vmNetworks = _vmNetworkMapDao.getNetworks(vmId);
-                    List<DomainRouterVO> routers = new ArrayList<DomainRouterVO>();
-                    //List the stopped routers
-                    for(long vmNetworkId : vmNetworks) {
-                        List<DomainRouterVO> router = _routerDao.listStopped(vmNetworkId);
-                        routers.addAll(router);
-                    }
-                    //A vm may not have many nics attached and even fewer routers might be stopped (only in exceptional cases)
-                    //Safe to start the stopped router serially, this is consistent with the way how multiple networks are added to vm during deploy
-                    //and routers are started serially ,may revisit to make this process parallel
-                    for(DomainRouterVO routerToStart : routers) {
-                        s_logger.warn("Trying to start router " + routerToStart.getInstanceName() + " as part of vm: " + vm.getInstanceName() + " reboot");
-                        _virtualNetAppliance.startRouter(routerToStart.getId(),true);
-                    }
+            Host host = _hostDao.findById(vm.getHostId());
+            if (host.isDisabled()) {
+                s_logger.info("Performing full stop & start instead of reboot on vm " + vm.getInstanceName() + " due to host being disabled");
+                if (stopVirtualMachine(userId, vmId)) {
+                    startVirtualMachine(vmId, null, null, null);
                 }
-            } catch (ConcurrentOperationException e) {
-                throw new CloudRuntimeException("Concurrent operations on starting router. " + e);
-            } catch (Exception ex){
-                throw new CloudRuntimeException("Router start failed due to" + ex);
-            }finally {
-                s_logger.info("Rebooting vm " + vm.getInstanceName());
-                _itMgr.reboot(vm.getUuid(), null);
+            } else {
+                collectVmDiskStatistics(vm);
+                collectVmNetworkStatistics(vm);
+                DataCenterVO dc = _dcDao.findById(vm.getDataCenterId());
+                try {
+                    if (dc.getNetworkType() == DataCenter.NetworkType.Advanced) {
+                        //List all networks of vm
+                        List<Long> vmNetworks = _vmNetworkMapDao.getNetworks(vmId);
+                        List<DomainRouterVO> routers = new ArrayList<DomainRouterVO>();
+                        //List the stopped routers
+                        for(long vmNetworkId : vmNetworks) {
+                            List<DomainRouterVO> router = _routerDao.listStopped(vmNetworkId);
+                            routers.addAll(router);
+                        }
+                        //A vm may not have many nics attached and even fewer routers might be stopped (only in exceptional cases)
+                        //Safe to start the stopped router serially, this is consistent with the way how multiple networks are added to vm during deploy
+                        //and routers are started serially ,may revisit to make this process parallel
+                        for(DomainRouterVO routerToStart : routers) {
+                            s_logger.warn("Trying to start router " + routerToStart.getInstanceName() + " as part of vm: " + vm.getInstanceName() + " reboot");
+                            _virtualNetAppliance.startRouter(routerToStart.getId(),true);
+                        }
+                    }
+                } catch (ConcurrentOperationException e) {
+                    throw new CloudRuntimeException("Concurrent operations on starting router. " + e);
+                } catch (Exception ex){
+                    throw new CloudRuntimeException("Router start failed due to" + ex);
+                }finally {
+                    s_logger.info("Rebooting vm " + vm.getInstanceName());
+                    _itMgr.reboot(vm.getUuid(), null);
+                }
             }
             return _vmDao.findById(vmId);
         } else {

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -518,7 +518,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             "allow vm to deploy on different host if vm fails to deploy on the given host ", true);
 
    private static final ConfigKey<Boolean> drainDisabledOnReboot = new ConfigKey<>("Advanced", Boolean.class, "drain.disabled.on.reboot", "false",
-            "Drain VMs running on disabled clusters during reboot", true, ConfigKey.Scope.Cluster);
+            "Drain VMs running on disabled infrastructure during reboot", true, ConfigKey.Scope.Cluster);
 
 
     @Override

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -520,9 +520,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     private static final ConfigKey<Boolean> AllowDeployVmIfGivenHostFails = new ConfigKey<Boolean>("Advanced", Boolean.class, "allow.deploy.vm.if.deploy.on.given.host.fails", "false",
             "allow vm to deploy on different host if vm fails to deploy on the given host ", true);
 
-   private static final ConfigKey<Boolean> drainDisabledOnReboot = new ConfigKey<>("Advanced", Boolean.class, "drain.disabled.on.reboot", "false",
-            "Drain VMs running on disabled infrastructure during reboot", true, ConfigKey.Scope.Cluster);
-
 
     @Override
     public UserVmVO getVirtualMachine(long vmId) {
@@ -6424,7 +6421,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {EnableDynamicallyScaleVm, AllowUserExpungeRecoverVm, VmIpFetchWaitInterval, VmIpFetchTrialMax, VmIpFetchThreadPoolMax,
-            VmIpFetchTaskWorkers, AllowDeployVmIfGivenHostFails, drainDisabledOnReboot};
+            VmIpFetchTaskWorkers, AllowDeployVmIfGivenHostFails};
     }
 
     @Override

--- a/server/src/org/apache/cloudstack/cluster/ClusterDrainingManager.java
+++ b/server/src/org/apache/cloudstack/cluster/ClusterDrainingManager.java
@@ -1,0 +1,32 @@
+package org.apache.cloudstack.cluster;
+
+import com.cloud.dc.DataCenter;
+import com.cloud.deploy.DeploymentPlanner;
+import com.cloud.org.Cluster;
+
+/**
+ * Wrapper class around the config option 'drain.disabled.clusters' to enable injecting logic into multiple locations
+ */
+public interface ClusterDrainingManager {
+
+    /**
+     * Adds clusters that are draining to a deployment planner list of avoids
+     * @param dc
+     * @param avoids - modified in place
+     */
+    void addDrainingToAvoids(DataCenter dc, DeploymentPlanner.ExcludeList avoids);
+
+    /**
+     * Check if the given host is impacted by a cluster which is currently draining
+     * @param hostId
+     * @return true if the host should drain
+     */
+    boolean shouldDrainHost(Long hostId);
+
+    /**
+     * Check if a specific cluster is draining
+     * @param cluster
+     * @return
+     */
+    boolean isClusterDraining(Cluster cluster);
+}

--- a/server/src/org/apache/cloudstack/cluster/ClusterDrainingManagerImpl.java
+++ b/server/src/org/apache/cloudstack/cluster/ClusterDrainingManagerImpl.java
@@ -1,0 +1,68 @@
+package org.apache.cloudstack.cluster;
+
+import com.cloud.dc.DataCenter;
+import com.cloud.dc.dao.ClusterDao;
+import com.cloud.deploy.DeploymentPlanner;
+import com.cloud.host.Host;
+import com.cloud.host.dao.HostDao;
+import com.cloud.org.Cluster;
+import com.cloud.org.Grouping;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class ClusterDrainingManagerImpl implements ClusterDrainingManager, Configurable {
+    private static final ConfigKey<Boolean> drainDisabledClusters = new ConfigKey<>("Advanced", Boolean.class, "drain.disabled.clusters", "false",
+            "Drain VMs running on disabled clusters during reboot or start", true, ConfigKey.Scope.Cluster);
+
+    @Inject
+    private HostDao _hostDao;
+    @Inject
+    private ClusterDao _clusterDao;
+
+    @Override
+    public void addDrainingToAvoids(DataCenter dc, DeploymentPlanner.ExcludeList avoids) {
+        List<Long> disabledClusters = _clusterDao.listDisabledClusters(dc.getId(), null);
+        for (Long clusterId : disabledClusters) {
+            if (isClusterDrainOptionOn(clusterId)) {
+                avoids.addCluster(clusterId);
+            }
+        }
+    }
+
+    @Override
+    public boolean shouldDrainHost(Long hostId) {
+        Host host = _hostDao.findById(hostId);
+        if (isClusterDrainOptionOn(host.getClusterId())) {
+            Cluster cluster = _clusterDao.findById(host.getClusterId());
+            return host.isDisabled() || isClusterDisabled(cluster);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean isClusterDraining(Cluster cluster) {
+        return isClusterDrainOptionOn(cluster.getId()) && isClusterDisabled(cluster);
+    }
+
+    private boolean isClusterDisabled(Cluster cluster) {
+        return cluster.getAllocationState() == Grouping.AllocationState.Disabled;
+    }
+
+    private Boolean isClusterDrainOptionOn(long id) {
+        return drainDisabledClusters.valueIn(id);
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return ClusterDrainingManager.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey[] {drainDisabledClusters};
+    }
+}

--- a/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
+++ b/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
@@ -30,6 +30,7 @@ import javax.naming.ConfigurationException;
 
 import com.cloud.host.Host;
 import org.apache.cloudstack.affinity.dao.AffinityGroupDomainMapDao;
+import org.apache.cloudstack.cluster.ClusterDrainingManager;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -448,6 +449,11 @@ public class DeploymentPlanningManagerImplTest {
         @Bean
         public HostGpuGroupsDao hostGpuGroupsDap() {
             return Mockito.mock(HostGpuGroupsDao.class);
+        }
+
+        @Bean
+        public ClusterDrainingManager clusterDrainingManager() {
+            return Mockito.mock(ClusterDrainingManager.class);
         }
 
         public static class Library implements TypeFilter {

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -14158,7 +14158,8 @@
                             label: 'label.allocation.state',
                             indicator: {
                                 'Enabled': 'on',
-                                'Disabled': 'off'
+                                'Disabled': 'off',
+                                'Draining': 'off'
                             }
                         }
                     },
@@ -21998,7 +21999,7 @@
             allowedActions.push("unmanage");
             allowedActions.push("disable");
             //allowedActions.push("edit"); // No fields to edit
-        } else if (jsonObj.state == "Disabled") {
+        } else if (jsonObj.state == "Disabled" || jsonObj.state == "Draining") {
             //managed, allocation disabled
             allowedActions.push("unmanage");
             allowedActions.push("enable");


### PR DESCRIPTION
Adding checks to vm start to avoid disabled pods, clusters, and hosts. ACS will automatically handle moving storage to a relevant new cluster if necessary.

Adding a new config option `drain.disabled.clusters` which causes any reboot to validate that the pod/cluster/host that the VM is running on isn't disabled. If it is it will perform a full stop and start which will trigger the normal deploy logic and move the VM to new infrastructure that isn't disabled.