### PR TITLE
Ac 94 add network stats exclusion

### DIFF
--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManager.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManager.java
@@ -67,6 +67,8 @@ public interface VirtualNetworkApplianceManager extends Manager, VirtualNetworkA
             "If true, router minimum required version is checked before sending command", false);
     static final ConfigKey<Boolean> UseExternalDnsServers = new ConfigKey<Boolean>(Boolean.class, "use.external.dns", "Advanced", "false",
             "Bypass internal dns, use external dns1 and dns2", true, ConfigKey.Scope.Zone, null);
+    static final ConfigKey<String> NetworkStatsExclusionList = new ConfigKey<String>("Advanced", String.class, "network.stats.exclusion.list", "",
+            "CIDRs and IPs that are excluded from network usage stats", true, ConfigKey.Scope.Global);
 
     public static final int DEFAULT_ROUTER_VM_RAMSIZE = 256;            // 256M
     public static final int DEFAULT_ROUTER_CPU_MHZ = 500;                // 500 MHz

--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1491,6 +1491,11 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             }
         }
 
+        String exclusionList = NetworkStatsExclusionList.value().replaceAll("\\s", "");
+        if (!exclusionList.equals("")) {
+            buf.append(" network_stats_exclusion_list=").append(exclusionList);
+        }
+
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Boot Args for " + profile + ": " + buf.toString());
         }
@@ -2590,7 +2595,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] { UseExternalDnsServers, routerVersionCheckEnabled, SetServiceMonitor, RouterAlertsCheckInterval };
+        return new ConfigKey<?>[] { UseExternalDnsServers, routerVersionCheckEnabled, SetServiceMonitor, RouterAlertsCheckInterval, NetworkStatsExclusionList };
     }
 
     @Override

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -422,9 +422,13 @@ class CsIP:
             self.fw.append(
                 ["filter", "", "-A FORWARD -i eth0 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT"])
 
-        self.fw.append(['', 'front', '-A FORWARD -j NETWORK_STATS'])
-        self.fw.append(['', 'front', '-A INPUT -j NETWORK_STATS'])
-        self.fw.append(['', 'front', '-A OUTPUT -j NETWORK_STATS'])
+        self.fw.append(['', 'front', '-A FORWARD -j NETWORK_STATS_FILTER'])
+        self.fw.append(['', 'front', '-A INPUT -j NETWORK_STATS_FILTER'])
+        self.fw.append(['', 'front', '-A OUTPUT -j NETWORK_STATS_FILTER'])
+
+        self.fw.append(['', '', '-A NETWORK_STATS_FILTER -s 10.1.133.211 -j RETURN'])
+        self.fw.append(['', '', '-A NETWORK_STATS_FILTER -j NETWORK_STATS'])
+
         self.fw.append(['', '', '-A NETWORK_STATS -i eth0 -o eth2'])
         self.fw.append(['', '', '-A NETWORK_STATS -i eth2 -o eth0'])
         self.fw.append(['', '', '-A NETWORK_STATS -o eth2 ! -i eth0 -p tcp'])
@@ -489,11 +493,16 @@ class CsIP:
             self.fw.append(
                 ["mangle", "", "-A VPN_STATS_%s -i %s -m mark --mark 0x524/0xffffffff" % (self.dev, self.dev)])
             self.fw.append(
-                ["", "front", "-A FORWARD -j NETWORK_STATS_%s" % self.dev])
+                ["", "front", "-A FORWARD -j NETWORK_STATS_FILTER_%s" % self.dev])
+            self.fw.append(
+                ["", "front", "-A NETWORK_STATS_FILTER_%s -j NETWORK_STATS_%s" % (self.dev, self.dev)])
 
-        self.fw.append(["", "front", "-A FORWARD -j NETWORK_STATS"])
-        self.fw.append(["", "front", "-A INPUT -j NETWORK_STATS"])
-        self.fw.append(["", "front", "-A OUTPUT -j NETWORK_STATS"])
+        self.fw.append(["", "front", "-A FORWARD -j NETWORK_STATS_FILTER"])
+        self.fw.append(["", "front", "-A INPUT -j NETWORK_STATS_FILTER"])
+        self.fw.append(["", "front", "-A OUTPUT -j NETWORK_STATS_FILTER"])
+
+        self.fw.append(['', '', '-A NETWORK_STATS_FILTER -s 10.1.133.211 -j RETURN'])
+        self.fw.append(['', '', '-A NETWORK_STATS_FILTER -j NETWORK_STATS'])
 
         self.fw.append(["", "", "-A NETWORK_STATS -i eth0 -o eth2 -p tcp"])
         self.fw.append(["", "", "-A NETWORK_STATS -i eth2 -o eth0 -p tcp"])

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -496,7 +496,7 @@ class CsIP:
                 ["", "front", "-A FORWARD -j NETWORK_STATS_FILTER_%s" % self.dev])
             self.add_stats_exclusions("NETWORK_STATS_FILTER_%s" % self.dev)
             self.fw.append(
-                ["", "front", "-A NETWORK_STATS_FILTER_%s -j NETWORK_STATS_%s" % (self.dev, self.dev)])
+                ["", "", "-A NETWORK_STATS_FILTER_%s -j NETWORK_STATS_%s" % (self.dev, self.dev)])
 
         self.fw.append(["", "front", "-A FORWARD -j NETWORK_STATS_FILTER"])
         self.fw.append(["", "front", "-A INPUT -j NETWORK_STATS_FILTER"])

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -426,7 +426,7 @@ class CsIP:
         self.fw.append(['', 'front', '-A INPUT -j NETWORK_STATS_FILTER'])
         self.fw.append(['', 'front', '-A OUTPUT -j NETWORK_STATS_FILTER'])
 
-        self.fw.append(['', '', '-A NETWORK_STATS_FILTER -s 10.1.133.211 -j RETURN'])
+        self.fw.append(['', 'front', '-A NETWORK_STATS_FILTER -s 10.1.133.211 -j RETURN'])
         self.fw.append(['', '', '-A NETWORK_STATS_FILTER -j NETWORK_STATS'])
 
         self.fw.append(['', '', '-A NETWORK_STATS -i eth0 -o eth2'])
@@ -501,7 +501,7 @@ class CsIP:
         self.fw.append(["", "front", "-A INPUT -j NETWORK_STATS_FILTER"])
         self.fw.append(["", "front", "-A OUTPUT -j NETWORK_STATS_FILTER"])
 
-        self.fw.append(['', '', '-A NETWORK_STATS_FILTER -s 10.1.133.211 -j RETURN'])
+        self.fw.append(['', 'front', '-A NETWORK_STATS_FILTER -s 10.1.133.211 -j RETURN'])
         self.fw.append(['', '', '-A NETWORK_STATS_FILTER -j NETWORK_STATS'])
 
         self.fw.append(["", "", "-A NETWORK_STATS -i eth0 -o eth2 -p tcp"])

--- a/systemvm/debian/opt/cloud/bin/cs/CsConfig.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsConfig.py
@@ -112,3 +112,6 @@ class CsConfig(object):
             return 'mangle'
         else:
             return ""
+
+    def get_network_stats_exclusion_list(self):
+        return self.cl.get_network_stats_exclusion_list()

--- a/systemvm/debian/opt/cloud/bin/cs/CsDatabag.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDatabag.py
@@ -158,3 +158,8 @@ class CsCmdLine(CsDataBag):
         if 'advert_int' in self.idata():
             return self.idata()['advert_int']
         return 1
+
+    def get_network_stats_exclusion_list(self):
+        if 'network_stats_exclusion_list' in self.idata():
+            return self.idata()['network_stats_exclusion_list']
+        return False


### PR DESCRIPTION
Add new global config option 'network.stats.exclusion.list' that takes a comma separated list of CIDRs/IPs and uses them to populate iptables on the VR to prevent bytes sent or received from being counted toward network usage.

It is accomplished by passing the exclusion list in boot args to the VR which then get populated into an intermediate iptables chain NETWORK_STATS_FILTER which sits between the various points to record, and the NETWORK_STATS chain that does the actual recording. This will affect isolated networks and VPC networks in advanced zones. Due to the way the data is passed to the VR, it requires rebooting the VR to update the exclusion list.