### PR TITLE
AC-97 Allow for editing the name of the VM

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -1246,6 +1246,11 @@
                                     displayName: args.data.displayname
                                 });
                             }
+                            if (args.data.name != args.context.instances[0].name) {
+                                $.extend(data, {
+                                    name: args.data.name
+                                });
+                            }
                             $.ajax({
                                 url: createURL('updateVirtualMachine'),
                                 data: data,
@@ -2569,7 +2574,8 @@
                                 converter: cloudStack.converters.toLocalDate
                             },
                             name: {
-                                label: 'label.name'
+                                label: 'label.name',
+                                isEditable: true
                             },
                             id: {
                                 label: 'label.id'


### PR DESCRIPTION
Allow any user to edit the name of the VM in addition to the display name. Currently only allowed when the VM isn't running.