### PR TITLE
AC-95 supporting changes

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -994,7 +994,14 @@ public class KVMStorageProcessor implements StorageProcessor {
 
                     final KVMStoragePool primaryStorage = storagePoolMgr.getStoragePool(primaryStore.getPoolType(),
                             primaryStore.getUuid());
-                    if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot()) {
+                    // Check to see if the snapshotName contains '-snapshot-', if so, just blow away the file
+                    if (snapshotName.contains("-snapshot-")) {
+                        File snapshotFile = new File(primaryStorage.getLocalPath(), snapshotName);
+                        s_logger.info("Snapshot is nfs file based: " + snapshotFile.getPath());
+                        if (!snapshotFile.delete()) {
+                            s_logger.error("Failed to delete snapshot on primary");
+                        }
+                    } else if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot()) {
                         final DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
                         try {
                             vm.suspend();

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -878,6 +878,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         final boolean isCreatedFromVmSnapshot = (index == -1) ? true: false; // -1 means the snapshot is created from existing vm snapshot
         String snapshotName = snapshot.getPath().substring(index + 1);
         String descName = snapshotName;
+        // This signifies that it is an ONTAP plugin snapshot, so we change our behavior here
         if (snapshot.getPath().startsWith("/.snapshot")) {
             snapshotName = snapshot.getPath();
             descName = UUID.randomUUID().toString();
@@ -997,8 +998,7 @@ public class KVMStorageProcessor implements StorageProcessor {
 
                     final KVMStoragePool primaryStorage = storagePoolMgr.getStoragePool(primaryStore.getPoolType(),
                             primaryStore.getUuid());
-                        // Check to see if the snapshotName contains '-snapshot-', if so, just blow away the file
-                        if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot() && !snapshotName.contains("-snapshot-")) {
+                        if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot()) {
                             final DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
                             try {
                                 vm.suspend();
@@ -1033,7 +1033,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                     s_logger.error("Failed to delete snapshots on primary", ex);
                 }
             } else {
-                s_logger.debug("Ingoring removal of snapshot because this was created by ONTAP plugin");
+                s_logger.debug("Ignoring removal of snapshot because this was created by ONTAP plugin");
             }
 
         try {

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -877,10 +877,10 @@ public class KVMStorageProcessor implements StorageProcessor {
         final int index = snapshot.getPath().lastIndexOf("/");
         final boolean isCreatedFromVmSnapshot = (index == -1) ? true: false; // -1 means the snapshot is created from existing vm snapshot
         String snapshotName = snapshot.getPath().substring(index + 1);
+        String descName = snapshotName;
         if (snapshot.getPath().startsWith("/.snapshot")) {
             snapshotName = snapshot.getPath();
         }
-        String descName = snapshotName;
         final String volumePath = snapshot.getVolume().getPath();
         String snapshotDestPath = null;
         String snapshotRelPath = null;

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -995,13 +995,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                     final KVMStoragePool primaryStorage = storagePoolMgr.getStoragePool(primaryStore.getPoolType(),
                             primaryStore.getUuid());
                     // Check to see if the snapshotName contains '-snapshot-', if so, just blow away the file
-                    if (snapshotName.contains("-snapshot-")) {
-                        File snapshotFile = new File(primaryStorage.getLocalPath(), snapshotName);
-                        s_logger.info("Snapshot is nfs file based: " + snapshotFile.getPath());
-                        if (!snapshotFile.delete()) {
-                            s_logger.error("Failed to delete snapshot on primary");
-                        }
-                    } else if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot()) {
+                    if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot() && !snapshotName.contains("-snapshot-")) {
                         final DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
                         try {
                             vm.suspend();

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -880,6 +880,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         String descName = snapshotName;
         if (snapshot.getPath().startsWith("/.snapshot")) {
             snapshotName = snapshot.getPath();
+            descName = UUID.randomUUID().toString();
         }
         final String volumePath = snapshot.getVolume().getPath();
         String snapshotDestPath = null;

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -876,8 +876,10 @@ public class KVMStorageProcessor implements StorageProcessor {
         // NOTE: snapshot name is encoded in snapshot path
         final int index = snapshot.getPath().lastIndexOf("/");
         final boolean isCreatedFromVmSnapshot = (index == -1) ? true: false; // -1 means the snapshot is created from existing vm snapshot
-
-        final String snapshotName = snapshot.getPath().substring(index + 1);
+        String snapshotName = snapshot.getPath().substring(index + 1);
+        if (snapshot.getPath().startsWith("/.snapshot")) {
+            snapshotName = snapshot.getPath();
+        }
         String descName = snapshotName;
         final String volumePath = snapshot.getVolume().getPath();
         String snapshotDestPath = null;

--- a/scripts/storage/qcow2/managesnapshot.sh
+++ b/scripts/storage/qcow2/managesnapshot.sh
@@ -152,17 +152,6 @@ destroy_snapshot() {
     fi
     lvm lvremove -f "${vg}/${snapshotname}-cow"
   elif [ -f $disk ]; then
-     if [[ $snapshotname =~ .*-snapshot-.* ]]
-     then
-       local snapshotFile=`dirname $disk`/$snapshotname
-       rm $snapshotFile
-       if [ $? -gt 0 ]
-       then
-         printf "Unable to delete snapshot file ${snapshotFile}" >&2
-         return 1
-       fi
-       return 0
-     fi
      #delete all the existing disk snapshots
      $qemu_img snapshot -l $disk |tail -n +3| grep -i '[0-9a-z]\{8\}-[0-9a-z]\{4\}' | awk '{print $1}'|xargs -I {} $qemu_img snapshot -d {} $disk >&2
      if [ $? -gt 0 ]
@@ -234,20 +223,7 @@ backup_snapshot() {
       forceSharedWrite="-U"
     fi
 
-    # Is the snapshot a whole file clone?
-    if [[ $snapshotname =~ .*-snapshot-.* ]]
-    then
-      local snapshotFile=`dirname $disk`/$snapshotname
-      cp $snapshotFile $destPath/$destName
-      if [ $? -gt 0 ]
-      then
-        printf "Unable to copy snapshot file ${snapshotFile}" >&2
-        return 1
-      fi
-      return 0
-    fi
-
-    if [[ $snapshotname =~ .*\.snapshot.* ]]
+    if [[ $snapshotname =~ \/\.snapshot.* ]]
     then
       local snapshotFile=`dirname $disk`$snapshotname
       cp $snapshotFile $destPath/$destName

--- a/scripts/storage/qcow2/managesnapshot.sh
+++ b/scripts/storage/qcow2/managesnapshot.sh
@@ -247,6 +247,18 @@ backup_snapshot() {
       return 0
     fi
 
+    if [[ $snapshotname =~ .*\.snapshot.* ]]
+    then
+      local snapshotFile=`dirname $disk`$snapshotname
+      cp $snapshotFile $destPath/$destName
+      if [ $? -gt 0 ]
+      then
+        printf "Unable to copy snapshot file ${snapshotFile}" >&2
+        return 1
+      fi
+      return 0
+    fi
+
     # Does the snapshot exist?
     $qemu_img snapshot $forceSharedWrite -l $disk|grep -w "$snapshotname" >& /dev/null
     if [ $? -gt 0 ]

--- a/scripts/storage/qcow2/managesnapshot.sh
+++ b/scripts/storage/qcow2/managesnapshot.sh
@@ -247,6 +247,14 @@ backup_snapshot() {
       return 0
     fi
 
+    # Does the snapshot exist?
+    $qemu_img snapshot $forceSharedWrite -l $disk|grep -w "$snapshotname" >& /dev/null
+    if [ $? -gt 0 ]
+    then
+      printf "there is no $snapshotname on disk $disk\n" >&2
+      return 1
+    fi
+
     $qemu_img convert $forceSharedWrite -f qcow2 -O qcow2 -s $snapshotname $disk $destPath/$destName >& /dev/null
     if [ $? -gt 0 ]
     then


### PR DESCRIPTION
To support some backend processes ACS and KVM use, add some additional checks for snapshots containing the name '-snapshot-' to treat them as separate files.