### PR TITLE
allow cert renewal even if auth strictness is false

### DIFF
--- a/plugins/ca/root-ca/src/org/apache/cloudstack/ca/provider/RootCAProvider.java
+++ b/plugins/ca/root-ca/src/org/apache/cloudstack/ca/provider/RootCAProvider.java
@@ -267,9 +267,16 @@ public final class RootCAProvider extends AdapterBase implements CAProvider, Con
         final boolean allowExpiredCertificate = rootCAAllowExpiredCert.value();
 
         TrustManager[] tms = new TrustManager[]{new RootCACustomTrustManager(remoteAddress, authStrictness, allowExpiredCertificate, certMap, caCertificate, crlDao)};
+
         sslContext.init(kmf.getKeyManagers(), tms, new SecureRandom());
         final SSLEngine sslEngine = sslContext.createSSLEngine();
-        sslEngine.setNeedClientAuth(authStrictness);
+        // If authStrictness require SSL and validate client cert, otherwise prefer SSL but don't validate client cert
+        if (authStrictness) {
+            sslEngine.setNeedClientAuth(true);  // Require SSL and client cert validation
+        } else {
+            sslEngine.setWantClientAuth(true);  // Prefer SSL but don't validate client cert
+        }
+
         return sslEngine;
     }
 

--- a/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCACustomTrustManagerTest.java
+++ b/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCACustomTrustManagerTest.java
@@ -62,10 +62,44 @@ public class RootCACustomTrustManagerTest {
     }
 
     @Test
-    public void testAuthNotStrict() throws Exception {
+    public void testAuthNotStrictWithInvalidCert() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(new CrlVO());
         final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
         trustManager.checkClientTrusted(null, null);
-        Assert.assertNull(trustManager.getAcceptedIssuers());
+    }
+
+    @Test
+    public void testAuthNotStrictWithRevokedCert() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(new CrlVO());
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{caCertificate}, "RSA");
+        Assert.assertTrue(certMap.containsKey(clientIp));
+        Assert.assertEquals(certMap.get(clientIp), caCertificate);
+    }
+
+    @Test
+    public void testAuthNotStrictWithInvalidCertOwnership() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(null);
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{caCertificate}, "RSA");
+        Assert.assertTrue(certMap.containsKey(clientIp));
+        Assert.assertEquals(certMap.get(clientIp), caCertificate);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void testAuthNotStrictWithDenyExpiredCertAndOwnership() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(null);
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, false, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{expiredClientCertificate}, "RSA");
+    }
+
+    @Test
+    public void testAuthNotStrictWithAllowExpiredCertAndOwnership() throws Exception {
+        Mockito.when(crlDao.findBySerial(Mockito.any(BigInteger.class))).thenReturn(null);
+        final RootCACustomTrustManager trustManager = new RootCACustomTrustManager(clientIp, false, true, certMap, caCertificate, crlDao);
+        trustManager.checkClientTrusted(new X509Certificate[]{expiredClientCertificate}, "RSA");
+        Assert.assertTrue(certMap.containsKey(clientIp));
+        Assert.assertEquals(certMap.get(clientIp), expiredClientCertificate);
     }
 
     @Test(expected = CertificateException.class)

--- a/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
+++ b/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
@@ -41,7 +41,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Mockito;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RootCAProviderTest {
@@ -133,17 +135,20 @@ public class RootCAProviderTest {
 
     @Test
     public void testCreateSSLEngineWithoutAuthStrictness() throws Exception {
-        overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "false");
+        provider.rootCAAuthStrictness = Mockito.mock(ConfigKey.class);
+        Mockito.when(provider.rootCAAuthStrictness.value()).thenReturn(Boolean.FALSE);
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
-        Assert.assertFalse(e.getUseClientMode());
+
+        Assert.assertTrue(e.getWantClientAuth());
         Assert.assertFalse(e.getNeedClientAuth());
     }
 
     @Test
     public void testCreateSSLEngineWithAuthStrictness() throws Exception {
-        overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "true");
+        provider.rootCAAuthStrictness = Mockito.mock(ConfigKey.class);
+        Mockito.when(provider.rootCAAuthStrictness.value()).thenReturn(Boolean.TRUE);
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
-        Assert.assertFalse(e.getUseClientMode());
+
         Assert.assertTrue(e.getNeedClientAuth());
     }
 


### PR DESCRIPTION
KVM Certs not renewing correctly.  Email excerpts below discussing.  Also linking to a version of this PR that was merged into community master (branch: https://github.com/ippathways/cloudstack/tree/sml-master-cert-renewal).

We must have missed merging this into our 4.11-ipp branch in the past.


On Mar 11, 2021, at 4:09 PM, Greg Goodrich <[GGoodrich@ippathways.com<mailto:GGoodrich@ippathways.com](mailto:GGoodrich@ippathways.com%3cmailto:GGoodrich@ippathways.com)>> wrote:

We have just discovered in our Lab environment that the certificates for libvirtd did not auto renew. Thus when we did an update, and restart of the agent, it failed to start, due to Libvirtd failing to start from an expired certificate. We then checked our production hosts, and their certificates are due to expire in 4 days, even though our setting is to auto renew at 15 days. Has anyone else encountered a problem with this? It appears to be related to this feature - https://github.com/apache/cloudstack/pull/2505.

We are running 4.11.3 in both environments.




From: Sean Lair <[slair@ippathways.com](mailto:slair@ippathways.com)> 
Sent: Monday, March 15, 2021 12:18 PM
To: [dev@cloudstack.apache.org](mailto:dev@cloudstack.apache.org)
Subject: RE: Secure Live Migration for KVM

Hi Rohit from our initial debugging, the issue may be a little more involved.  Maybe you could add some insight.

We added some debug logging to monitor the size of the activeCertMap and have noticed it is almost always 0.  When the CABackgroundTask runs, it never does anything because the in memory activeCertMaps on each mgmt server is empty.

When a KVM host connects to a mgmt server, we do not see any code that populates the activeCertMap with the newly connected host's Cert.  Shouldn't a host connection trigger adding the host's cert to the activeCertMap?

Furthermore, when a cert is provisioned from the web-interface/API for a host, we do see the activeCertMap initially being populated.  However, as part of that process, the agent is restarted.  That restart of the agent triggers the following method in AgentManagerImpl.java:

protected boolean handleDisconnectWithoutInvestigation(final AgentAttache attache, final Status.Event event, final boolean transitState, final boolean removeAgent)

That method ends up calling the following method which removes the host/cert from the activeCertMap:
caService.purgeHostCertificate(host);

Now, since at host reconnect there isn't any code to re-populate the activeCertMap, it remains at 0 and as mentioned the CABackgroundTask never has anything to do, thus certs never get renewed.


From: Sean Lair <[slair@ippathways.com](mailto:slair@ippathways.com)>
Sent: Tuesday, March 16, 2021 2:43:24 AM
To: [dev@cloudstack.apache.org](mailto:dev@cloudstack.apache.org) <[dev@cloudstack.apache.org](mailto:dev@cloudstack.apache.org)>
Subject: RE: Secure Live Migration for KVM

Quick update so no one spends any time looking into this.  Found a few things that we are working to fix:

1. if ca.plugin.root.auth.strictness is set to false, CloudStack will not try to renew any certs it has issued.  I'd say this is an issue, it should still renew certs it has issued.
2. if the KVM agent is connecting to the management servers via a load-balancer, then the management servers see's the load-balancer's IP address as the client IP address.  This causes the client certificate trust check to fail, as the load-balancer IP address is not in the cert's Subject Alternative Names list.
3. Similar to #2, the CA background task also has an issue when KVM agents come through a load-balancer

We'll fix #2 and #3 by having the KVM agents connect directly to the mgmt servers.