### PR TITLE
AC-110 restrict public template access

### DIFF
--- a/api/src/org/apache/cloudstack/query/QueryService.java
+++ b/api/src/org/apache/cloudstack/query/QueryService.java
@@ -86,6 +86,9 @@ public interface QueryService {
     static final ConfigKey<Boolean> AllowUserViewDestroyedVM = new ConfigKey<Boolean>("Advanced", Boolean.class, "allow.user.view.destroyed.vm", "false",
             "Determines whether users can view their destroyed or expunging vm ", true, ConfigKey.Scope.Account);
 
+    ConfigKey<Boolean> RestrictPublicTemplateAccessToDomain = new ConfigKey<>("Advanced", Boolean.class, "restrict.public.template.access.to.domain", "false",
+            "Prevents a domain from seeing the public templates of another sibling domain. Does not prevent seeing parent or child templates", true, ConfigKey.Scope.Global);
+
     ListResponse<UserResponse> searchForUsers(ListUsersCmd cmd) throws PermissionDeniedException;
 
     ListResponse<EventResponse> searchForEvents(ListEventsCmd cmd);

--- a/server/src/com/cloud/acl/DomainChecker.java
+++ b/server/src/com/cloud/acl/DomainChecker.java
@@ -18,6 +18,7 @@ package com.cloud.acl;
 
 import javax.inject.Inject;
 
+import org.apache.cloudstack.query.QueryService;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.acl.ControlledEntity;
@@ -127,6 +128,10 @@ public class DomainChecker extends AdapterBase implements SecurityChecker {
                         if (owner.getType() != Account.ACCOUNT_TYPE_PROJECT || !(_projectMgr.canAccessProjectAccount(caller, owner.getId()))) {
                             throw new PermissionDeniedException("Domain Admin and regular users can modify only their own Public templates");
                         }
+                    }
+                } else if (QueryService.RestrictPublicTemplateAccessToDomain.value()) {
+                    if (!_domainDao.isChildDomain(owner.getDomainId(), caller.getDomainId())) {
+                        throw new PermissionDeniedException(caller + " is not allowed to access template " + template);
                     }
                 }
             }

--- a/server/src/com/cloud/acl/DomainChecker.java
+++ b/server/src/com/cloud/acl/DomainChecker.java
@@ -129,8 +129,9 @@ public class DomainChecker extends AdapterBase implements SecurityChecker {
                             throw new PermissionDeniedException("Domain Admin and regular users can modify only their own Public templates");
                         }
                     }
-                } else if (QueryService.RestrictPublicTemplateAccessToDomain.value()) {
-                    if (!_domainDao.isChildDomain(owner.getDomainId(), caller.getDomainId())) {
+                } else if (QueryService.RestrictPublicTemplateAccessToDomain.value() && caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
+                    // Look both up the tree and down from the caller's position
+                    if (!_domainDao.isChildDomain(owner.getDomainId(), caller.getDomainId()) && !_domainDao.isChildDomain(caller.getDomainId(), owner.getDomainId())) {
                         throw new PermissionDeniedException(caller + " is not allowed to access template " + template);
                     }
                 }

--- a/server/src/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/com/cloud/api/query/QueryManagerImpl.java
@@ -3166,7 +3166,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 sc.addAnd("domainPath", SearchCriteria.Op.LIKE, domain.getPath() + "%");
             }
 
-            boolean publicTemplates = (templateFilter == TemplateFilter.featured || templateFilter == TemplateFilter.community || templateFilter == TemplateFilter.all);
+            boolean publicTemplates = (templateFilter == TemplateFilter.featured || templateFilter == TemplateFilter.community || templateFilter == TemplateFilter.all || templateFilter == TemplateFilter.executable);
             List<Long> relatedDomainIds = new ArrayList<Long>();
             List<Long> permittedAccountIds = new ArrayList<Long>();
             if (!permittedAccounts.isEmpty()) {
@@ -3232,7 +3232,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             }
 
             SearchCriteria<TemplateJoinVO> sc_public = _templateJoinDao.createSearchCriteria();
-            if (templateFilter == TemplateFilter.featured || templateFilter == TemplateFilter.community || templateFilter == TemplateFilter.all || templateFilter == TemplateFilter.executable) {
+            if (publicTemplates) {
                 sc_public.addAnd("publicTemplate", SearchCriteria.Op.EQ, true);
 
                 if (RestrictPublicTemplateAccessToDomain.value() && !relatedDomainIds.isEmpty()) {

--- a/server/src/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/com/cloud/api/query/QueryManagerImpl.java
@@ -3063,7 +3063,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             accountId = userAccount != null ? userAccount.getAccountId() : null;
         }
 
-        boolean showDomr = ((templateFilter != TemplateFilter.selfexecutable) && (templateFilter != TemplateFilter.featured));
+        boolean showDomr = ((templateFilter != TemplateFilter.selfexecutable) && (templateFilter != TemplateFilter.featured) && _accountMgr.isRootAdmin(caller.getId()));
         HypervisorType hypervisorType = HypervisorType.getType(cmd.getHypervisor());
 
         return searchForTemplatesInternal(id, cmd.getTemplateName(), cmd.getKeyword(), templateFilter, false, null, cmd.getPageSizeVal(), cmd.getStartIndex(), cmd.getZoneId(), hypervisorType,
@@ -3130,6 +3130,8 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             // if template is not public, perform permission check here
             else if (!template.isPublicTemplate() && caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
                 _accountMgr.checkAccess(caller, null, false, template);
+            } else if (template.isPublicTemplate() && RestrictPublicTemplateAccessToDomain.value()) {
+                _accountMgr.checkAccess(caller, null, false, template);
             }
 
             // if templateId is specified, then we will just use the id to
@@ -3164,35 +3166,57 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 sc.addAnd("domainPath", SearchCriteria.Op.LIKE, domain.getPath() + "%");
             }
 
+            boolean publicTemplates = (templateFilter == TemplateFilter.featured || templateFilter == TemplateFilter.community || templateFilter == TemplateFilter.all);
             List<Long> relatedDomainIds = new ArrayList<Long>();
             List<Long> permittedAccountIds = new ArrayList<Long>();
             if (!permittedAccounts.isEmpty()) {
                 for (Account account : permittedAccounts) {
                     permittedAccountIds.add(account.getId());
-                    boolean publicTemplates = (templateFilter == TemplateFilter.featured || templateFilter == TemplateFilter.community);
 
                     // get all parent domain ID's all the way till root domain
                     DomainVO domainTreeNode = null;
                     //if template filter is featured, or community, all child domains should be included in search
-                    if (publicTemplates) {
+                    if (publicTemplates && !RestrictPublicTemplateAccessToDomain.value()) {
                         domainTreeNode = _domainDao.findById(Domain.ROOT_DOMAIN);
 
                     } else {
                         domainTreeNode = _domainDao.findById(account.getDomainId());
                     }
                     relatedDomainIds.add(domainTreeNode.getId());
+
+                    // Only get children of the account domain if we are restricting
+                    if (RestrictPublicTemplateAccessToDomain.value()) {
+                        if (_accountMgr.isAdmin(account.getId()) || publicTemplates) {
+                            List<DomainVO> allChildDomains = _domainDao.findAllChildren(domainTreeNode.getPath(), domainTreeNode.getId());
+                            for (DomainVO childDomain : allChildDomains) {
+                                relatedDomainIds.add(childDomain.getId());
+                            }
+                        }
+                    }
                     while (domainTreeNode.getParent() != null) {
                         domainTreeNode = _domainDao.findById(domainTreeNode.getParent());
                         relatedDomainIds.add(domainTreeNode.getId());
                     }
-
-                    // get all child domain ID's
-                    if (_accountMgr.isAdmin(account.getId()) || publicTemplates) {
-                        List<DomainVO> allChildDomains = _domainDao.findAllChildren(domainTreeNode.getPath(), domainTreeNode.getId());
-                        for (DomainVO childDomain : allChildDomains) {
-                            relatedDomainIds.add(childDomain.getId());
+                    if (!RestrictPublicTemplateAccessToDomain.value()) {
+                        // This more or less gets all domains in the system since it walks up the tree first
+                        if (_accountMgr.isAdmin(account.getId()) || publicTemplates) {
+                            List<DomainVO> allChildDomains = _domainDao.findAllChildren(domainTreeNode.getPath(), domainTreeNode.getId());
+                            for (DomainVO childDomain : allChildDomains) {
+                                relatedDomainIds.add(childDomain.getId());
+                            }
                         }
                     }
+                }
+            } else if (RestrictPublicTemplateAccessToDomain.value() && publicTemplates && caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
+                DomainVO domainTreeNode = _domainDao.findById(caller.getDomainId());
+                relatedDomainIds.add(domainTreeNode.getId());
+                List<DomainVO> allChildDomains = _domainDao.findAllChildren(domainTreeNode.getPath(), domainTreeNode.getId());
+                for (DomainVO childDomain : allChildDomains) {
+                    relatedDomainIds.add(childDomain.getId());
+                }
+                while (domainTreeNode.getParent() != null) {
+                    domainTreeNode = _domainDao.findById(domainTreeNode.getParent());
+                    relatedDomainIds.add(domainTreeNode.getId());
                 }
             }
 
@@ -3207,15 +3231,28 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 }
             }
 
+            SearchCriteria<TemplateJoinVO> sc_public = _templateJoinDao.createSearchCriteria();
+            if (templateFilter == TemplateFilter.featured || templateFilter == TemplateFilter.community || templateFilter == TemplateFilter.all || templateFilter == TemplateFilter.executable) {
+                sc_public.addAnd("publicTemplate", SearchCriteria.Op.EQ, true);
+
+                if (RestrictPublicTemplateAccessToDomain.value() && !relatedDomainIds.isEmpty()) {
+                    SearchCriteria<TemplateJoinVO> sc_domains = _templateJoinDao.createSearchCriteria();
+                    sc_domains.addOr("domainId", SearchCriteria.Op.IN, relatedDomainIds.toArray());
+                    sc_domains.addOr("domainId", SearchCriteria.Op.NULL);
+
+                    sc_public.addAnd("domainId", SearchCriteria.Op.SC, sc_domains);
+                }
+            }
+
             // control different template filters
             if (templateFilter == TemplateFilter.featured || templateFilter == TemplateFilter.community) {
-                sc.addAnd("publicTemplate", SearchCriteria.Op.EQ, true);
+                sc.addAnd("publicTemplate", SearchCriteria.Op.SC, sc_public);
                 if (templateFilter == TemplateFilter.featured) {
                     sc.addAnd("featured", SearchCriteria.Op.EQ, true);
                 } else {
                     sc.addAnd("featured", SearchCriteria.Op.EQ, false);
                 }
-                if (!permittedAccounts.isEmpty()) {
+                if (!permittedAccounts.isEmpty() && !RestrictPublicTemplateAccessToDomain.value()) {
                     SearchCriteria<TemplateJoinVO> scc = _templateJoinDao.createSearchCriteria();
                     scc.addOr("domainId", SearchCriteria.Op.IN, relatedDomainIds.toArray());
                     scc.addOr("domainId", SearchCriteria.Op.NULL);
@@ -3230,14 +3267,14 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 sc.addAnd("sharedAccountId", SearchCriteria.Op.IN, permittedAccountIds.toArray());
             } else if (templateFilter == TemplateFilter.executable) {
                 SearchCriteria<TemplateJoinVO> scc = _templateJoinDao.createSearchCriteria();
-                scc.addOr("publicTemplate", SearchCriteria.Op.EQ, true);
+                scc.addAnd("publicTemplate", SearchCriteria.Op.SC, sc_public);
                 if (!permittedAccounts.isEmpty()) {
                     scc.addOr("accountId", SearchCriteria.Op.IN, permittedAccountIds.toArray());
                 }
                 sc.addAnd("publicTemplate", SearchCriteria.Op.SC, scc);
             } else if (templateFilter == TemplateFilter.all && caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
                 SearchCriteria<TemplateJoinVO> scc = _templateJoinDao.createSearchCriteria();
-                scc.addOr("publicTemplate", SearchCriteria.Op.EQ, true);
+                scc.addOr("publicTemplate", SearchCriteria.Op.SC, sc_public);
 
                 if (listProjectResourcesCriteria == ListProjectResourcesCriteria.SkipProjectResources) {
                     scc.addOr("domainPath", SearchCriteria.Op.LIKE, _domainDao.findById(caller.getDomainId()).getPath() + "%");
@@ -3708,6 +3745,6 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {AllowUserViewDestroyedVM};
+        return new ConfigKey<?>[] {AllowUserViewDestroyedVM, RestrictPublicTemplateAccessToDomain};
     }
 }

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -528,6 +528,7 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
 import org.apache.cloudstack.framework.security.keystore.KeystoreManager;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.cloudstack.query.QueryService;
 import org.apache.cloudstack.resourcedetail.dao.GuestOsDetailsDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
@@ -3428,7 +3429,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         KVMSnapshotEnabled = Boolean.parseBoolean(_configDao.getValue("KVM.snapshot.enabled"));
 
         boolean isAdmin = _accountService.isAdmin(caller.getId());
-        final boolean userPublicTemplateEnabled = (TemplateManager.AllowPublicUserTemplates.valueIn(caller.getId()) | isAdmin);
+        final boolean userPublicTemplateEnabled = (TemplateManager.AllowPublicUserTemplates.valueIn(caller.getId()) | (isAdmin && QueryService.RestrictPublicTemplateAccessToDomain.value()));
 
         // add some parameters UI needs to handle API throttling
         final boolean apiLimitEnabled = Boolean.parseBoolean(_configDao.getValue(Config.ApiLimitEnabled.key()));

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -3427,15 +3427,16 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final long diskOffMaxSize = VolumeOrchestrationService.CustomDiskOfferingMaxSize.value();
         KVMSnapshotEnabled = Boolean.parseBoolean(_configDao.getValue("KVM.snapshot.enabled"));
 
-        final boolean userPublicTemplateEnabled = TemplateManager.AllowPublicUserTemplates.valueIn(caller.getId());
+        boolean isAdmin = _accountService.isAdmin(caller.getId());
+        final boolean userPublicTemplateEnabled = (TemplateManager.AllowPublicUserTemplates.valueIn(caller.getId()) | isAdmin);
 
         // add some parameters UI needs to handle API throttling
         final boolean apiLimitEnabled = Boolean.parseBoolean(_configDao.getValue(Config.ApiLimitEnabled.key()));
         final Integer apiLimitInterval = Integer.valueOf(_configDao.getValue(Config.ApiLimitInterval.key()));
         final Integer apiLimitMax = Integer.valueOf(_configDao.getValue(Config.ApiLimitMax.key()));
 
-        final boolean allowUserViewDestroyedVM = (QueryManagerImpl.AllowUserViewDestroyedVM.valueIn(caller.getId()) | _accountService.isAdmin(caller.getId()));
-        final boolean allowUserExpungeRecoverVM = (UserVmManager.AllowUserExpungeRecoverVm.valueIn(caller.getId()) | _accountService.isAdmin(caller.getId()));
+        final boolean allowUserViewDestroyedVM = (QueryManagerImpl.AllowUserViewDestroyedVM.valueIn(caller.getId()) | isAdmin);
+        final boolean allowUserExpungeRecoverVM = (UserVmManager.AllowUserExpungeRecoverVm.valueIn(caller.getId()) | isAdmin);
 
         // check if region-wide secondary storage is used
         boolean regionSecondaryEnabled = false;

--- a/server/src/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/com/cloud/template/TemplateAdapterBase.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.api.command.user.template.GetUploadParamsForTemplateCmd;
+import org.apache.cloudstack.query.QueryService;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 
@@ -191,11 +192,13 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
         // check whether owner can create public templates
         boolean allowPublicUserTemplates = TemplateManager.AllowPublicUserTemplates.valueIn(templateOwner.getId());
         boolean isAdmin = _accountMgr.isAdmin(templateOwner.getId());
-        if (!isAdmin && !allowPublicUserTemplates && isPublic) {
+        boolean isAdminWhoCanUploadPublicTemplates = isRootAdmin || (isAdmin && QueryService.RestrictPublicTemplateAccessToDomain.value());
+
+        if (!isAdminWhoCanUploadPublicTemplates && !allowPublicUserTemplates && isPublic) {
             throw new InvalidParameterValueException("Only private templates/ISO can be created.");
         }
 
-        if (!isRootAdmin || featured == null) {
+        if (!isAdminWhoCanUploadPublicTemplates || featured == null) {
             featured = Boolean.FALSE;
         }
 

--- a/server/src/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/com/cloud/template/TemplateAdapterBase.java
@@ -179,7 +179,7 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
         }
 
         if (!isRootAdmin && zoneIdList == null && !isRegionStore ) {
-            // domain admin and user should also be able to register template on a region store
+            // Root admin and user should also be able to register template on a region store
             throw new InvalidParameterValueException("Please specify a valid zone Id. Only admins can create templates in all zones.");
         }
 

--- a/server/src/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/com/cloud/template/TemplateAdapterBase.java
@@ -171,14 +171,14 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
             sshkeyEnabled = Boolean.FALSE;
         }
 
-        boolean isAdmin = _accountMgr.isRootAdmin(templateOwner.getId());
+        boolean isRootAdmin = _accountMgr.isRootAdmin(templateOwner.getId());
         boolean isRegionStore = false;
         List<ImageStoreVO> stores = _imgStoreDao.findRegionImageStores();
         if (stores != null && stores.size() > 0) {
             isRegionStore = true;
         }
 
-        if (!isAdmin && zoneIdList == null && !isRegionStore ) {
+        if (!isRootAdmin && zoneIdList == null && !isRegionStore ) {
             // domain admin and user should also be able to register template on a region store
             throw new InvalidParameterValueException("Please specify a valid zone Id. Only admins can create templates in all zones.");
         }
@@ -190,11 +190,12 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
 
         // check whether owner can create public templates
         boolean allowPublicUserTemplates = TemplateManager.AllowPublicUserTemplates.valueIn(templateOwner.getId());
+        boolean isAdmin = _accountMgr.isAdmin(templateOwner.getId());
         if (!isAdmin && !allowPublicUserTemplates && isPublic) {
             throw new InvalidParameterValueException("Only private templates/ISO can be created.");
         }
 
-        if (!isAdmin || featured == null) {
+        if (!isRootAdmin || featured == null) {
             featured = Boolean.FALSE;
         }
 

--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -1262,6 +1262,9 @@ cloudStack.preFilter = {
             args.$form.find('.form-item[rel=isPublic]').css('display', 'inline-block');
             args.$form.find('.form-item[rel=isFeatured]').css('display', 'inline-block');
             args.$form.find('.form-item[rel=isrouting]').css('display', 'inline-block');
+        } else if (isDomainAdmin() && g_userPublicTemplateEnabled === "true") {
+            args.$form.find('.form-item[rel=isPublic]').css('display', 'inline-block');
+            args.$form.find('.form-item[rel=isFeatured]').css('display', 'inline-block');
         } else {
             if (g_userPublicTemplateEnabled == "true") {
                 args.$form.find('.form-item[rel=isPublic]').css('display', 'inline-block');


### PR DESCRIPTION
Adding global setting to limit public templates to the domain tree the template lives in
Updating 'allow.public.user.templates' global setting to still allow domain and resource admins to upload public templates.