### PR TITLE
AC-103 VPC Private Gateways Bypass VLAN Overlap Check

### DIFF
--- a/api/src/com/cloud/network/NetworkService.java
+++ b/api/src/com/cloud/network/NetworkService.java
@@ -172,7 +172,8 @@ public interface NetworkService {
      * @param networkName
      * @param displayText
      * @param physicalNetworkId
-     * @param broadcastUri TODO set the guru name based on the broadcastUri?
+     * @param broadcastUri           TODO set the guru name based on the broadcastUri?
+     * @param bypassVlanOverlapCheck
      * @param startIp
      * @param endIP TODO
      * @param gateway
@@ -185,8 +186,8 @@ public interface NetworkService {
      * @throws ConcurrentOperationException
      * @throws ResourceAllocationException
      */
-    Network createPrivateNetwork(String networkName, String displayText, long physicalNetworkId, String broadcastUri, String startIp, String endIP, String gateway,
-        String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId) throws ResourceAllocationException, ConcurrentOperationException,
+    Network createPrivateNetwork(String networkName, String displayText, long physicalNetworkId, String broadcastUri, Boolean bypassVlanOverlapCheck, String startIp, String endIP, String gateway,
+                                 String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId) throws ResourceAllocationException, ConcurrentOperationException,
         InsufficientCapacityException;
 
     /* Requests an IP address for the guest nic */

--- a/api/src/com/cloud/network/vpc/VpcService.java
+++ b/api/src/com/cloud/network/vpc/VpcService.java
@@ -149,6 +149,7 @@ public interface VpcService {
      * @param vpcId TODO
      * @param physicalNetworkId
      * @param vlan
+     * @param bypassVlanOverlapCheck
      * @param ipAddress
      * @param gateway
      * @param netmask
@@ -161,8 +162,8 @@ public interface VpcService {
      * @throws ConcurrentOperationException
      * @throws ResourceAllocationException
      */
-    public PrivateGateway createVpcPrivateGateway(long vpcId, Long physicalNetworkId, String vlan, String ipAddress, String gateway, String netmask, long gatewayOwnerId,
-            Long networkOfferingId, Boolean isSoruceNat, Long aclId) throws ResourceAllocationException, ConcurrentOperationException, InsufficientCapacityException;
+    public PrivateGateway createVpcPrivateGateway(long vpcId, Long physicalNetworkId, String vlan, Boolean bypassVlanOverlapCheck, String ipAddress, String gateway, String netmask, long gatewayOwnerId,
+                                                  Long networkOfferingId, Boolean isSoruceNat, Long aclId) throws ResourceAllocationException, ConcurrentOperationException, InsufficientCapacityException;
 
     /**
      * Applies VPC private gateway on the backend, so it becomes functional

--- a/api/src/org/apache/cloudstack/api/command/admin/vpc/CreatePrivateGatewayCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/vpc/CreatePrivateGatewayCmd.java
@@ -72,6 +72,9 @@ public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
     @Parameter(name = ApiConstants.VLAN, type = CommandType.STRING, required = true, description = "the network implementation uri for the private gateway")
     private String broadcastUri;
 
+    @Parameter(name=ApiConstants.BYPASS_VLAN_OVERLAP_CHECK, type=CommandType.BOOLEAN, description="when true bypasses VLAN id/range overlap check during network creation for shared and L2 networks")
+    private Boolean bypassVlanOverlapCheck;
+
     @Parameter(name = ApiConstants.NETWORK_OFFERING_ID,
                type = CommandType.UUID,
                required = false,
@@ -102,6 +105,13 @@ public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
 
     public String getBroadcastUri() {
         return broadcastUri;
+    }
+
+    public Boolean getBypassVlanOverlapCheck() {
+        if (bypassVlanOverlapCheck == null) {
+            return false;
+        }
+        return bypassVlanOverlapCheck;
     }
 
     public String getNetmask() {
@@ -148,7 +158,7 @@ public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
         PrivateGateway result = null;
         try {
             result =
-                _vpcService.createVpcPrivateGateway(getVpcId(), getPhysicalNetworkId(), getBroadcastUri(), getStartIp(), getGateway(), getNetmask(), getEntityOwnerId(),
+                _vpcService.createVpcPrivateGateway(getVpcId(), getPhysicalNetworkId(), getBroadcastUri(), getBypassVlanOverlapCheck(), getStartIp(), getGateway(), getNetmask(), getEntityOwnerId(),
                     getNetworkOfferingId(), getIsSourceNat(), getAclId());
         } catch (InsufficientCapacityException ex) {
             s_logger.info(ex);

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2194,13 +2194,13 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         if (vlanSpecified) {
             URI uri = BroadcastDomainType.fromString(vlanId);
             //don't allow to specify vlan tag used by physical network for dynamic vlan allocation
-            if (!hasGuestBypassVlanOverlapCheck(bypassVlanOverlapCheck, ntwkOff) && _dcDao.findVnet(zoneId, pNtwk.getId(), BroadcastDomainType.getValue(uri)).size() > 0) {
+            if (!bypassVlanOverlapCheck && _dcDao.findVnet(zoneId, pNtwk.getId(), BroadcastDomainType.getValue(uri)).size() > 0) {
                 throw new InvalidParameterValueException("The VLAN tag " + vlanId + " is already being used for dynamic vlan allocation for the guest network in zone "
                         + zone.getName());
             }
             if (! UuidUtils.validateUUID(vlanId)){
                 // For Isolated and L2 networks, don't allow to create network with vlan that already exists in the zone
-                if (ntwkOff.getGuestType() == GuestType.Isolated || !hasGuestBypassVlanOverlapCheck(bypassVlanOverlapCheck, ntwkOff)) {
+                if (!bypassVlanOverlapCheck) {
                     if (_networksDao.listByZoneAndUriAndGuestType(zoneId, uri.toString(), null).size() > 0) {
                         throw new InvalidParameterValueException("Network with vlan " + vlanId + " already exists or overlaps with other network vlans in zone " + zoneId);
                     } else {
@@ -2388,16 +2388,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         return network;
     }
 
-  /**
-   * Checks bypass VLAN id/range overlap check during network creation for guest networks
-   * @param bypassVlanOverlapCheck bypass VLAN id/range overlap check
-   * @param ntwkOff network offering
-   */
-  private boolean hasGuestBypassVlanOverlapCheck(final boolean bypassVlanOverlapCheck, final NetworkOfferingVO ntwkOff) {
-    return bypassVlanOverlapCheck && ntwkOff.getGuestType() != GuestType.Isolated;
-  }
-
-  /**
+    /**
      * Checks for L2 network offering services. Only 2 cases allowed:
      * - No services
      * - User Data service only, provided by ConfigDrive

--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -4300,8 +4300,8 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
 
     @Override
     @DB
-    public Network createPrivateNetwork(final String networkName, final String displayText, long physicalNetworkId, String broadcastUriString, final String startIp, String endIp,
-            final String gateway, String netmask, final long networkOwnerId, final Long vpcId, final Boolean sourceNat, final Long networkOfferingId)
+    public Network createPrivateNetwork(final String networkName, final String displayText, long physicalNetworkId, String broadcastUriString, Boolean bypassVlanOverlapCheck, final String startIp, String endIp,
+                                        final String gateway, String netmask, final long networkOwnerId, final Long vpcId, final Boolean sourceNat, final Long networkOfferingId)
                     throws ResourceAllocationException, ConcurrentOperationException, InsufficientCapacityException {
 
         final Account owner = _accountMgr.getAccount(networkOwnerId);
@@ -4362,7 +4362,7 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
                     Network privateNetwork = _networksDao.getPrivateNetwork(uriString, cidr, networkOwnerId, pNtwk.getDataCenterId(), networkOfferingId);
                     if (privateNetwork == null) {
                         //create Guest network
-                        privateNetwork = _networkMgr.createGuestNetwork(ntwkOffFinal.getId(), networkName, displayText, gateway, cidr, uriString, false, null, owner, null, pNtwk,
+                        privateNetwork = _networkMgr.createGuestNetwork(ntwkOffFinal.getId(), networkName, displayText, gateway, cidr, uriString, bypassVlanOverlapCheck, null, owner, null, pNtwk,
                                                                         pNtwk.getDataCenterId(), ACLType.Account, null, vpcId, null, null, true, null, null);
                         if (privateNetwork != null) {
                             s_logger.debug("Successfully created guest network " + privateNetwork);

--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1584,8 +1584,8 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @Override
     @DB
     @ActionEvent(eventType = EventTypes.EVENT_PRIVATE_GATEWAY_CREATE, eventDescription = "creating VPC private gateway", create = true)
-    public PrivateGateway createVpcPrivateGateway(final long vpcId, Long physicalNetworkId, final String broadcastUri, final String ipAddress, final String gateway,
-            final String netmask, final long gatewayOwnerId, final Long networkOfferingId, final Boolean isSourceNat, final Long aclId) throws ResourceAllocationException,
+    public PrivateGateway createVpcPrivateGateway(final long vpcId, Long physicalNetworkId, final String broadcastUri, Boolean bypassVlanOverlapCheck, final String ipAddress, final String gateway,
+                                                  final String netmask, final long gatewayOwnerId, final Long networkOfferingId, final Boolean isSourceNat, final Long aclId) throws ResourceAllocationException,
             ConcurrentOperationException, InsufficientCapacityException {
 
         // Validate parameters
@@ -1633,7 +1633,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                     if (privateNtwk == null) {
                         s_logger.info("creating new network for vpc " + vpc + " using broadcast uri: " + broadcastUri);
                         final String networkName = "vpc-" + vpc.getName() + "-privateNetwork";
-                        privateNtwk = _ntwkSvc.createPrivateNetwork(networkName, networkName, physicalNetworkIdFinal, broadcastUri, ipAddress, null, gateway, netmask,
+                        privateNtwk = _ntwkSvc.createPrivateNetwork(networkName, networkName, physicalNetworkIdFinal, broadcastUri, bypassVlanOverlapCheck, ipAddress, null, gateway, netmask,
                                 gatewayOwnerId, vpcId, isSourceNat, networkOfferingId);
                     } else { // create the nic/ip as createPrivateNetwork
                         // doesn''t do that work for us now

--- a/server/test/com/cloud/network/CreatePrivateNetworkTest.java
+++ b/server/test/com/cloud/network/CreatePrivateNetworkTest.java
@@ -137,21 +137,21 @@ public class CreatePrivateNetworkTest {
         /* Network nw; */
         try {
             /* nw = */
-            networkService.createPrivateNetwork("bla", "fake", 1L, "vlan:1", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, true, 1L);
+            networkService.createPrivateNetwork("bla", "fake", 1L, "vlan:1", false, "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, true, 1L);
             /* nw = */
-            networkService.createPrivateNetwork("bla", "fake", 1L, "lswitch:3", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, false, 1L);
+            networkService.createPrivateNetwork("bla", "fake", 1L, "lswitch:3", false, "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, false, 1L);
             boolean invalid = false;
             boolean unsupported = false;
             try {
                 /* nw = */
-                networkService.createPrivateNetwork("bla", "fake", 1, "bla:2", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, true, 1L);
+                networkService.createPrivateNetwork("bla", "fake", 1, "bla:2", false, "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, true, 1L);
             } catch (CloudRuntimeException e) {
                 Assert.assertEquals("unexpected parameter exception", "string 'bla:2' has an unknown BroadcastDomainType.", e.getMessage());
                 invalid = true;
             }
             try {
                 /* nw = */
-                networkService.createPrivateNetwork("bla", "fake", 1, "mido://4", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, false, 1L);
+                networkService.createPrivateNetwork("bla", "fake", 1, "mido://4", false, "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, false, 1L);
             } catch (InvalidParameterValueException e) {
                 Assert.assertEquals("unexpected parameter exception", "unsupported type of broadcastUri specified: mido://4", e.getMessage());
                 unsupported = true;

--- a/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -503,8 +503,8 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
      * @see com.cloud.network.NetworkService#createPrivateNetwork(java.lang.String, java.lang.String, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, long, java.lang.Long)
      */
     @Override
-    public Network createPrivateNetwork(String networkName, String displayText, long physicalNetworkId, String vlan, String startIp, String endIP, String gateway,
-        String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId) throws ResourceAllocationException, ConcurrentOperationException,
+    public Network createPrivateNetwork(String networkName, String displayText, long physicalNetworkId, String vlan, Boolean bypassVlanOverlapCheck, String startIp, String endIP, String gateway,
+                                        String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId) throws ResourceAllocationException, ConcurrentOperationException,
         InsufficientCapacityException {
         // TODO Auto-generated method stub
         return null;

--- a/ui/scripts/vpc.js
+++ b/ui/scripts/vpc.js
@@ -2095,6 +2095,10 @@
                                             },
                                             docID: 'helpVPCGatewayVLAN'
                                         },
+                                        bypassVlanOverlapCheck: {
+                                            label: 'label.bypass.vlan.overlap.check',
+                                            isBoolean: true
+                                        },
                                         ipaddress: {
                                             label: 'label.ip.address',
                                             validation: {
@@ -2168,6 +2172,11 @@
                                         array1.push("&sourcenatsupported=true");
                                     } else
                                         array1.push("&sourcenatsupported=false");
+
+                                    if (args.$form.find('.form-item[rel=bypassVlanOverlapCheck]').find('input[type=checkbox]').is(':Checked') == true) {
+                                        array1.push("&bypassvlanoverlapcheck=true");
+                                    } else
+                                        array1.push("&bypassvlanoverlapcheck=false");
 
 
                                     $.ajax({


### PR DESCRIPTION
Adding the ability for VPC private gateways to overlap the normal VLAN ranges. By default VPC private gateway networks are of type Isolated. So I had to pull out most of the checks around the offering guest type being Isolated for overlaps.
