### PR TITLE
Handle DB updates more cleanly in dev and lab

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -654,7 +654,8 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 final CloudStackVersion currentVersion = CloudStackVersion.parse(currentVersionValue);
                 s_logger.info("DB version = " + dbVersion + " Code Version = " + currentVersion);
 
-                if (dbVersion.compareTo(currentVersion) > 0) {
+                // Bypass this check, but only for security patches. This allows for testing in dev and lab going back and forth in versions.
+                if (dbVersion.compareToWithoutSecurity(currentVersion) > 0) {
                     throw new CloudRuntimeException("Database version " + dbVersion + " is higher than management software version " + currentVersionValue);
                 }
 

--- a/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -659,7 +659,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                     throw new CloudRuntimeException("Database version " + dbVersion + " is higher than management software version " + currentVersionValue);
                 }
 
-                if (dbVersion.compareTo(currentVersion) == 0) {
+                if (dbVersion.compareTo(currentVersion) >= 0) {
                     s_logger.info("DB version and code version matches so no upgrade needed.");
                     return;
                 }

--- a/utils/src/main/java/org/apache/cloudstack/utils/CloudStackVersion.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/CloudStackVersion.java
@@ -166,6 +166,27 @@ public final class CloudStackVersion implements Comparable<CloudStackVersion> {
 
     }
 
+    public int compareToWithoutSecurity(final CloudStackVersion thatVersion) {
+
+        if (thatVersion == null) {
+            return 1;
+        }
+
+        // Normalize the versions to be 4 positions for the purposes of comparison ...
+        final ImmutableList<Integer> values = normalizeVersionValues(asListWithoutSecurity());
+        final ImmutableList<Integer> thoseValues = normalizeVersionValues(thatVersion.asListWithoutSecurity());
+
+        for (int i = 0; i < values.size(); i++) {
+            final int result = values.get(i).compareTo(thoseValues.get(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        return 0;
+
+    }
+
     /**
      *
      * @return The components of this version as an {@link ImmutableList} in order of major release, minor release,
@@ -185,6 +206,14 @@ public final class CloudStackVersion implements Comparable<CloudStackVersion> {
 
         return values.build();
 
+    }
+
+    public ImmutableList<Integer> asListWithoutSecurity() {
+
+        final ImmutableList.Builder<Integer> values = ImmutableList.<Integer>builder().add
+                (majorRelease, minorRelease, patchRelease);
+
+        return values.build();
     }
 
     @Override


### PR DESCRIPTION
This is to allow for more flexibility in how we handle our dev and lab environments with regards to automatic db upgrades. This will allow for us to use the security patch level (fourth number) of the version to track our db updates, but allow for going back and forth between different security patch levels. This does mean that we need to always make sure our db changes within a security patch level are backwards and forwards compatible, but it greatly simplifies managing dev and lab.

Examples:
* If the current db is 4.11.3.0 and we are deploying 4.11.3.1, it will apply any applicable db updates from 4.11.3.1.
* If the current db is 4.11.3.1 and we are deploying 4.11.3.0, no db upgrades will happen, and the mgmt server will start normally
* If the current db is 4.11.3.1 and we are deploying 4.11.4.0, the db will be upgraded to 4.11.4.0
* If the current db is 4.11.4.0 and we are deploying 4.11.3.x, the mgmt server will fail to start because it is more than a security patch difference in database and code versions 

The alternative to this is to manually update the db whenever we need to deploy a branch of an older security patch level to delete the new version. Which happens frequently during development.